### PR TITLE
ACD-10 Adds com.fasterxml to thirdparty-prefixes

### DIFF
--- a/debugger/src/main/resources/thirdparty-prefixes.txt
+++ b/debugger/src/main/resources/thirdparty-prefixes.txt
@@ -9,3 +9,4 @@ org.ops4j
 org.osgi
 org.springframework
 org.knopflerfish
+com.fasterxml


### PR DESCRIPTION
### Description of the Change
Adding prefix to account for artifacts like `com.fasterxml.woodstox.woodstox-core`

### Alternate Designs
N/A

### Benefits
Additional invalid solutions won't be printed out.

### Possible Drawbacks
N/A

### Verification Process
Built it locally and reran it with the same AccessControlException being thrown.

### Applicable Issues
Fixes: #10