### PR TITLE
ACD-14 Update backdoor pom file to mark 2 packages optional as done in Boon's bundle

### DIFF
--- a/backdoor/pom.xml
+++ b/backdoor/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -68,6 +70,11 @@
                         <Bundle-Vendor>Codice</Bundle-Vendor>
                         <Bundle-Activator>org.codice.acdebugger.backdoor.Backdoor</Bundle-Activator>
                         <Embed-Dependency>acdebugger-common, boon</Embed-Dependency>
+                        <Import-Package> <!-- imports specific as optional for embedding boon -->
+                            com.sun.management;resolution:=optional,
+                            sun.misc;resolution:=optional,
+                            *
+                        </Import-Package>
                         <Require-Capability>
                             osgi.service;filter:="(objectClass=org.codice.acdebugger.PermissionService)";effective:=active;resolution:=optional
                         </Require-Capability>


### PR DESCRIPTION
### Description of the Change
The backdoor bundle which is embedding Boon is requiring com.sun.management and sun.misc which are normally marked optional in Boon's bundle. This is causing startup issue when those are not found.
The changes provided here simply forces those 2 packages to be optional as done in Boon's bundle.

The maven bundle plugin which uses the bndtool underneath doesn't have a way to preserve the optional imported packages defined in an embedded bundle.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed
version was selected
-->

### Benefits
<!--
What benefits will be realized by the code change?
-->
It allows system to startup since the packages are not really required by the code invoked in Boon by the backdoor.

### Possible Drawbacks
<!--
What are the possible side-effects or negative impacts of the code change?
-->
If Boon's requirements changes, this code has to be updated.

### Verification Process
Open the manifest file for the backdoor bundle and ensures that the 2 packages mentioned in the issue are tagged as being optional.

### Applicable Issues
<!--
Enter applicable Issues here
-->
Fixes: #14 