### PR TITLE
Added cli parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ be run by doing: `java -jar acdebugger-debugger-1.0-SNAPSHOT-jar-with-dependenci
 
 ### Options
 The following debugger options are available:
-* -host `<hostname or IP>`
-* -port `<port number>`
-* -wait `[<timeout>]`
-* -continuous
-* -admin
-* -dump
-* -service
-* -grant
+* --host `<hostname or IP>`
+* --port `<port number>`
+* --wait 
+* --wait-timeout `[<timeout>]` (only applies when `--wait` is used)
+* --continuous
+* --admin
+* --dump
+* --service
+* --grant
+* --help
+* --version
 
 ### Typical Output
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -47,9 +47,20 @@
             <artifactId>picocli</artifactId>
             <version>3.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.2</version>
+        </dependency>
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -67,7 +78,7 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
-                </executions>
+              </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>3.5.2</version>
+            <version>${picocli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.2</version>
+            <version>${awaitility.version}</version>
         </dependency>
     </dependencies>
 

--- a/debugger/pom.xml
+++ b/debugger/pom.xml
@@ -42,6 +42,11 @@
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>3.5.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -1,10 +1,14 @@
 package org.codice.acdebugger;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
 import java.net.ConnectException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.codice.acdebugger.breakpoints.AccessControlContextCheckBreakpointProcessor;
 import org.codice.acdebugger.breakpoints.BackdoorProcessor;
+import org.codice.acdebugger.cli.PropertiesVersionProvider;
 import org.codice.acdebugger.impl.Debugger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -12,42 +16,57 @@ import picocli.CommandLine.Option;
 @Command(
   description = "Purpose-built debugger for determining missing OSGi bundle security permissions.",
   name = "acdebugger",
-  mixinStandardHelpOptions = true
+  mixinStandardHelpOptions = true,
+  versionProvider = PropertiesVersionProvider.class
 )
 public class ACDebugger implements Callable<Void> {
 
   @Option(
     names = {"-a", "--admin"},
     description =
-        "Indicates the tool is being run for an admin. In such cases, the analysis won't be as extensive since an administrator wouldn't be able to modify the code for example. At the moment, it disables analyzing solutions that involve extending privileges in bundles using doPrivileged() blocks. In the above example, only the second solution would have been reported if this option had been provided. As such, this option should not be used by developers."
+        "Indicates the tool is being run for an admin. In such cases, the analysis won't be as extensive"
+            + " since an administrator wouldn't be able to modify the code for example. At the moment, "
+            + "it disables analyzing solutions that involve extending privileges in bundles using "
+            + "doPrivileged() blocks. In the above example, only the second solution would have been "
+            + "reported if this option had been provided. As such, this option should not be used by developers."
   )
   private boolean admin = false;
 
   @Option(
     names = {"-c", "--continuous"},
     description =
-        "Specifies to run in continuous mode where the debugger will tell the VM not to fail on any security failures detected and report on all failures found."
+        "Specifies to run in continuous mode where the debugger will tell the VM not to fail on any security"
+            + " failures detected and report on all failures found."
   )
   private boolean continuous = false;
 
   @Option(
     names = {"-d", "--dump"},
     description =
-        "Additional information about detected security failures such as stack traces and bundle information will be printed along with solutions."
+        "Additional information about detected security failures such as stack traces and bundle information "
+            + "will be printed along with solutions."
   )
   private boolean dumping = false;
 
   @Option(
     names = {"-g", "--grant"},
     description =
-        "When specified, the debugger will use the backdoor and a registered ServicePermission service to temporarily grant permissions for detected security failures which after analysis yields a single solution. This is only temporary and will not survive a restart of the VM but will prevent any further failures that would otherwise not be if the permission(s) were defined. It also tends to slow down the system since the OSGi permission cache ends up being cleared each time."
+        "When specified, the debugger will use the backdoor and a registered ServicePermission service to "
+            + "temporarily grant permissions for detected security failures which after analysis yields a "
+            + "single solution. This is only temporary and will not survive a restart of the VM but will "
+            + "prevent any further failures that would otherwise not be if the permission(s) were defined. "
+            + "It also tends to slow down the system since the OSGi permission cache ends up being cleared each time."
   )
   private boolean granting = false;
 
   @Option(
     names = {"-s", "--service"},
     description =
-        "Specifies that a breakpoint should be added in Eclipse's Service Registry to detect internal security checks done for given bundles before dispatching service events. These failures are analyzed and reported as normal security check failures. This option tends to slow down the system a bit as the debugger is invoked for all checks and not just when a failure is about to be reported."
+        "Specifies that a breakpoint should be added in Eclipse's Service Registry to detect internal "
+            + "security checks done for given bundles before dispatching service events. These failures "
+            + "are analyzed and reported as normal security check failures. This option tends to slow down "
+            + "the system a bit as the debugger is invoked for all checks and not just when a failure is "
+            + "about to be reported."
   )
   private boolean service = false;
 
@@ -102,7 +121,7 @@ public class ACDebugger implements Callable<Void> {
             || (System.currentTimeMillis() > startTime + TimeUnit.MINUTES.toMillis(timeout))) {
           System.exit(1);
         } else {
-          TimeUnit.SECONDS.sleep(30);
+          await().atMost(30, SECONDS);
         }
       }
     }

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -1,0 +1,125 @@
+package org.codice.acdebugger;
+
+import java.net.ConnectException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.codice.acdebugger.breakpoints.AccessControlContextCheckBreakpointProcessor;
+import org.codice.acdebugger.breakpoints.BackdoorProcessor;
+import org.codice.acdebugger.impl.Debugger;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+  description = "Purpose-built debugger for determining missing OSGi bundle security permissions.",
+  name = "acdebugger",
+  mixinStandardHelpOptions = true
+)
+public class ACDebugger implements Callable<Void> {
+
+  @Option(
+    names = {"-a", "--admin"},
+    description =
+        "Indicates the tool is being run for an admin. In such cases, the analysis won't be as extensive since an administrator wouldn't be able to modify the code for example. At the moment, it disables analyzing solutions that involve extending privileges in bundles using doPrivileged() blocks. In the above example, only the second solution would have been reported if this option had been provided. As such, this option should not be used by developers."
+  )
+  private boolean admin = false;
+
+  @Option(
+    names = {"-c", "--continuous"},
+    description =
+        "Specifies to run in continuous mode where the debugger will tell the VM not to fail on any security failures detected and report on all failures found."
+  )
+  private boolean continuous = false;
+
+  @Option(
+    names = {"-d", "--dump"},
+    description =
+        "Additional information about detected security failures such as stack traces and bundle information will be printed along with solutions."
+  )
+  private boolean dumping = false;
+
+  @Option(
+    names = {"-g", "--grant"},
+    description =
+        "When specified, the debugger will use the backdoor and a registered ServicePermission service to temporarily grant permissions for detected security failures which after analysis yields a single solution. This is only temporary and will not survive a restart of the VM but will prevent any further failures that would otherwise not be if the permission(s) were defined. It also tends to slow down the system since the OSGi permission cache ends up being cleared each time."
+  )
+  private boolean granting = false;
+
+  @Option(
+    names = {"-s", "--service"},
+    description =
+        "Specifies that a breakpoint should be added in Eclipse's Service Registry to detect internal security checks done for given bundles before dispatching service events. These failures are analyzed and reported as normal security check failures. This option tends to slow down the system a bit as the debugger is invoked for all checks and not just when a failure is about to be reported."
+  )
+  private boolean service = false;
+
+  @Option(
+    names = {"-t", "--transport"},
+    description = "Specifies the transport to use when connecting to the VM."
+  )
+  String transport = "dt_socket";
+
+  @Option(
+    names = {"-H", "--host"},
+    description = "Specifies the host or IP where the VM to attach to is located."
+  )
+  String host = "localhost";
+
+  @Option(
+    names = {"-p", "--port"},
+    description = "Specifies the port number the VM is awaiting debuggers to connect to."
+  )
+  String port = "5005";
+
+  @Option(
+    names = {"-w", "--wait"},
+    description =
+        "Indicates to wait for a connection. To specify the timeout value use with the '--wait-timeout' option."
+  )
+  boolean wait = false;
+
+  @Option(
+    names = {"--wait-timeout"},
+    description =
+        "Only applies when the '--wait' option is used. Sets the maximum number of minutes to wait"
+  )
+  long timeout = 10;
+
+  @Override
+  public Void call() throws Exception {
+
+    final long startTime = System.currentTimeMillis();
+    Debugger debugger = null;
+
+    // attach to VM
+    while (debugger == null) {
+      try {
+        debugger = new Debugger(transport, host, port).attach();
+      } catch (ConnectException e) {
+        System.err.println("Unable to connect to " + host + ":" + port + " over " + transport);
+        if (!wait
+            || (System.currentTimeMillis() > startTime + TimeUnit.MINUTES.toMillis(timeout))) {
+          System.exit(1);
+        } else {
+          TimeUnit.SECONDS.sleep(30);
+        }
+      }
+    }
+    // configure options
+    debugger.setContinuous(continuous);
+    debugger.setDumping(dumping);
+    debugger.setGranting(granting);
+    debugger.setMonitoringService(service);
+    if (admin) {
+      debugger.setDoPrivilegedBlocks(false);
+    } else {
+      debugger.setDoPrivilegedBlocks(true);
+    }
+
+    // registering breakpoints
+    debugger.add(new BackdoorProcessor());
+    debugger.add(new AccessControlContextCheckBreakpointProcessor());
+    // debugger.add(new ImpliesBreakpointProcessor()); // This slows the system to a crawl :-(
+
+    debugger.loop();
+    return null;
+  }
+}

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -53,19 +53,22 @@ public class ACDebugger implements Callable<Void> {
 
   @Option(
     names = {"-t", "--transport"},
-    description = "Specifies the transport to use when connecting to the VM."
+    description =
+        "Specifies the transport to use when connecting to the VM. (default: ${DEFAULT-VALUE})"
   )
   String transport = "dt_socket";
 
   @Option(
     names = {"-H", "--host"},
-    description = "Specifies the host or IP where the VM to attach to is located."
+    description =
+        "Specifies the host or IP where the VM to attach to is located. (default: ${DEFAULT-VALUE})"
   )
   String host = "localhost";
 
   @Option(
     names = {"-p", "--port"},
-    description = "Specifies the port number the VM is awaiting debuggers to connect to."
+    description =
+        "Specifies the port number the VM is awaiting debuggers to connect to. (default:${DEFAULT-VALUE})"
   )
   String port = "5005";
 
@@ -79,7 +82,7 @@ public class ACDebugger implements Callable<Void> {
   @Option(
     names = {"--wait-timeout"},
     description =
-        "Only applies when the '--wait' option is used. Sets the maximum number of minutes to wait"
+        "Only applies when the '--wait' option is used. Sets the maximum number of minutes to wait. (default: ${DEFAULT-VALUE})"
   )
   long timeout = 10;
 

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -130,11 +130,7 @@ public class ACDebugger implements Callable<Void> {
     debugger.setDumping(dumping);
     debugger.setGranting(granting);
     debugger.setMonitoringService(service);
-    if (admin) {
-      debugger.setDoPrivilegedBlocks(false);
-    } else {
-      debugger.setDoPrivilegedBlocks(true);
-    }
+    debugger.setDoPrivilegedBlocks(!admin);
 
     // registering breakpoints
     debugger.add(new BackdoorProcessor());

--- a/debugger/src/main/java/org/codice/acdebugger/Main.java
+++ b/debugger/src/main/java/org/codice/acdebugger/Main.java
@@ -1,94 +1,9 @@
 package org.codice.acdebugger;
 
-import java.net.ConnectException;
-import java.util.concurrent.TimeUnit;
-import org.codice.acdebugger.breakpoints.AccessControlContextCheckBreakpointProcessor;
-import org.codice.acdebugger.breakpoints.BackdoorProcessor;
-import org.codice.acdebugger.impl.Debugger;
+import picocli.CommandLine;
 
 public class Main {
   public static void main(String[] args) throws Exception {
-    String transport = "dt_socket";
-    String host = "localhost";
-    String port = "5005";
-    long timeout = 10;
-    boolean wait = false;
-    boolean continuous = false;
-    boolean dumping = false;
-    boolean granting = false;
-    boolean service = false;
-    boolean doPrivileged = true;
-
-    if (args.length > 0) {
-      for (int i = 0; i < args.length; i++) {
-        switch (args[i]) {
-          case "-admin":
-            doPrivileged = false;
-            break;
-          case "-continuous":
-            continuous = true;
-            break;
-          case "-dump":
-            dumping = true;
-            break;
-          case "-grant":
-            granting = true;
-            break;
-          case "-service":
-            service = true;
-            break;
-          case "-transport":
-            transport = args[++i];
-            break;
-          case "-host":
-            host = args[++i];
-            break;
-          case "-port":
-            port = args[++i];
-            break;
-          case "-wait":
-            if ((i + 1 <= args.length - 1) && !args[i + 1].startsWith("-")) {
-              try {
-                timeout = Long.valueOf(args[++i]);
-                System.out.println("Set wait period to: " + timeout);
-              } catch (NumberFormatException e) {
-                System.err.println("Must use a decimal value in minutes for timeout");
-              }
-            }
-            wait = true;
-            break;
-        }
-      }
-    }
-    final long startTime = System.currentTimeMillis();
-    Debugger debugger = null;
-
-    // attach to VM
-    while (debugger == null) {
-      try {
-        debugger = new Debugger(transport, host, port).attach();
-      } catch (ConnectException e) {
-        System.err.println("Unable to connect to " + host + ":" + port + " over " + transport);
-        if (!wait
-            || (System.currentTimeMillis() > startTime + TimeUnit.MINUTES.toMillis(timeout))) {
-          System.exit(1);
-        } else {
-          TimeUnit.SECONDS.sleep(30);
-        }
-      }
-    }
-    // configure options
-    debugger.setContinuous(continuous);
-    debugger.setDumping(dumping);
-    debugger.setGranting(granting);
-    debugger.setMonitoringService(service);
-    debugger.setDoPrivilegedBlocks(doPrivileged);
-
-    // registering breakpoints
-    debugger.add(new BackdoorProcessor());
-    debugger.add(new AccessControlContextCheckBreakpointProcessor());
-    // debugger.add(new ImpliesBreakpointProcessor()); // This slows the system to a crawl :-(
-
-    debugger.loop();
+    CommandLine.call(new ACDebugger(), args);
   }
 }

--- a/debugger/src/main/java/org/codice/acdebugger/cli/PropertiesVersionProvider.java
+++ b/debugger/src/main/java/org/codice/acdebugger/cli/PropertiesVersionProvider.java
@@ -1,0 +1,39 @@
+package org.codice.acdebugger.cli;
+
+import java.net.URL;
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Implements a {@link IVersionProvider} that reads version information from a version.properties
+ * file in a jar Adapted from the picocli example:
+ * https://github.com/remkop/picocli/blob/master/examples/src/main/java/picocli/examples/VersionProviderDemo1.java
+ *
+ * <p>Supports the following version properties:
+ *
+ * <ul>
+ *   <li>Application-Title
+ *   <li>Application-Version
+ * </ul>
+ */
+public class PropertiesVersionProvider implements IVersionProvider {
+
+  private static final String TITLE_PROPERTY_NAME = "application.title";
+  private static final String VERSION_PROPERTY_NAME = "application.version";
+
+  @Override
+  public String[] getVersion() throws Exception {
+    URL url = getClass().getResource("/version.properties");
+    if (url == null) {
+      return new String[] {"No version.properties file found in the classpath."};
+    }
+    Properties properties = new Properties();
+    properties.load(url.openStream());
+    return new String[] {
+      properties.getProperty(TITLE_PROPERTY_NAME)
+          + " version: \""
+          + properties.getProperty(VERSION_PROPERTY_NAME)
+          + "\""
+    };
+  }
+}

--- a/debugger/src/main/resources/version.properties
+++ b/debugger/src/main/resources/version.properties
@@ -1,0 +1,2 @@
+application.title = ${project.parent.artifactId}
+application.version = ${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
         <boon.version>0.34</boon.version>
         <osgi.version>5.0.0</osgi.version>
         <jsr305.version>3.0.2_1</jsr305.version>
+        <picocli.version>3.5.2</picocli.version>
+        <awaitility.version>3.1.2</awaitility.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
### Description of the Change

This change replaces the manual string parsing with a Cli parsing library. 
The command line options have been updated to include both long and short options.
All short flags can be combined for more concise command usage, for example: `<command> -acsgw` would be equivalent to `<command> --admin --continuous --service --grant --wait`.
Additionally a single optional argument could be included as the last option in a list of short options, for example: `<command> -acsgwH some.host` would be equivalent to: `<command> --admin --continuous --service --grant --wait --host some.host`.
Help text has been added for all options and a `--help` or `-h` option is now included:

```bash
Usage: acdebugger [-acdghsVw] [--wait-timeout=<timeout>] [-H=<host>]      
                  [-p=<port>] [-t=<transport>]
Purpose-built debugger for determining missing OSGi bundle security permissions.
      --wait-timeout=<timeout>
                      Only applies when the '--wait' option is used. Sets the
                        maximum number of minutes to wait. (default: 10)
  -a, --admin         Indicates the tool is being run for an admin. In such cases,
                        the analysis won't be as extensive since an administrator
                        wouldn't be able to modify the code for example. At the
                        moment, it disables analyzing solutions that involve
                        extending privileges in bundles using doPrivileged() blocks.
                        In the above example, only the second solution would have
                        been reported if this option had been provided. As such,
                        this option should not be used by developers.
  -c, --continuous    Specifies to run in continuous mode where the debugger will
                        tell the VM not to fail on any security failures detected
                        and report on all failures found.
  -d, --dump          Additional information about detected security failures such
                        as stack traces and bundle information will be printed along
                        with solutions.
  -g, --grant         When specified, the debugger will use the backdoor and a
                        registered ServicePermission service to temporarily grant
                        permissions for detected security failures which after
                        analysis yields a single solution. This is only temporary
                        and will not survive a restart of the VM but will prevent
                        any further failures that would otherwise not be if the
                        permission(s) were defined. It also tends to slow down the
                        system since the OSGi permission cache ends up being cleared
                        each time.
  -h, --help          Show this help message and exit.
  -H, --host=<host>   Specifies the host or IP where the VM to attach to is located.
                        (default: localhost)
  -p, --port=<port>   Specifies the port number the VM is awaiting debuggers to
                        connect to. (default:5005)
  -s, --service       Specifies that a breakpoint should be added in Eclipse's
                        Service Registry to detect internal security checks done for
                        given bundles before dispatching service events. These
                        failures are analyzed and reported as normal security check
                        failures. This option tends to slow down the system a bit as
                        the debugger is invoked for all checks and not just when a
                        failure is about to be reported.
  -t, --transport=<transport>
                      Specifies the transport to use when connecting to the VM.
                        (default: dt_socket)
  -V, --version       Print version information and exit.
  -w, --wait          Indicates to wait for a connection. To specify the timeout
                        value use with the '--wait-timeout' option.
```


### Alternate Designs

### Benefits
Better command line parsing, self documenting cli options.

### Possible Drawbacks


### Verification Process


### Applicable Issues
Fixes: #7 

### Remaining Tasks
- [x] Update Readme
- [x] Add version option to CLI
- [x] Add `awaitility`
- [x] Clean up long description code format