### PR TITLE
ACD-19, ACD-20, ACD-21 Support for acceptable failures and enhanced bundle determination logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Purpose-built debugger for determining missing OSGi bundle security permissions.
 The current implementation will put a breakpoint on line 472 of
 `java.security.AccessControlContext` (the throws clause), analyze and report possible solutions to the security failure. 
 It will do so for a single failure and exit unless the `-continuous` option is used in which case it will let the VM continue as if no failures had occurred and report for all failures (unless they were already detected and reported).
-The debugger also accounts for acceptable security failures. These are security failures that occurs in specific parts of the system which are deemed acceptable and for which no permissions requires granting. 
-This is typically the case when the code actually handles such exception appropriately without consequences. When such failures are detected, the debugger will simply ignore them and let them fail normally without reporting them (unless the --dump option is specified).
+The debugger also accounts for acceptable security failures. These are security failures that occurs in specific parts of the system which are deemed acceptable and for which no permissions need to be granted. 
+This is typically the case when the code actually handles such exceptions appropriately without consequences. When such failures are detected, the debugger will simply ignore them and let them fail normally without reporting them (unless the --dump option is specified).
 
 It also provides an option where it will put a breakpoint on line 1096 of `org.eclipse.osgi.internal.serviceregistry.ServiceRegistry` to detect all service permission checks done before the registry dispatches service events to other bundles. 
 This option is not on by default as it can slow down the system a bit.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The current implementation will put a breakpoint on line 472 of
 `java.security.AccessControlContext` (the throws clause), analyze and report possible solutions to the security failure. 
 It will do so for a single failure and exit unless the `-continuous` option is used in which case it will let the VM continue as if no failures had occurred and report for all failures (unless they were already detected and reported).
 The debugger also accounts for acceptable security failures. These are security failures that occurs in specific parts of the system which are deemed acceptable and for which no permissions need to be granted. 
-This is typically the case when the code actually handles such exceptions appropriately without consequences. When such failures are detected, the debugger will simply ignore them and let them fail normally without reporting them (unless the --dump option is specified).
+This is typically the case when the code actually handles such exceptions appropriately without consequences. When such failures are detected, the debugger will simply ignore them and let them fail normally without reporting them (unless the --debug option is specified).
 
 It also provides an option where it will put a breakpoint on line 1096 of `org.eclipse.osgi.internal.serviceregistry.ServiceRegistry` to detect all service permission checks done before the registry dispatches service events to other bundles. 
 This option is not on by default as it can slow down the system a bit.
@@ -41,39 +41,49 @@ As seen in the above example, the analysis gives priority to extending existing 
 
 ### Options
 The following debugger options are available:
-* --host `<hostname or IP>`
-* --port `<port number>`
-* --wait 
-* --wait-timeout `[<timeout>]` (only applies when `--wait` is used)
-* --continuous
-* --admin
-* --dump
-* --service
-* --grant
-* --help
-* --version
+* --help / -h
+* --host / -H `<hostname or IP>`
+* --port / -p `<port number>`
+* --wait / -w
+* --timeout `<timeout>` (only applies when `--wait` is used)
+* --continuous / -c
+* --admin / -a
+* --debug / -d
+* --service / -s
+* --grant / -g
+* --help / -h
+* --version / -V
 
-#### -host `<hostname or IP>`
+#### --help / -h 
+Prints out usage information and exit.
+
+#### --version / -V
+Prints version information and exit.
+
+#### --host / -H `<hostname or IP>`
 Specifies the host or IP where the VM to attach to is located
  
-#### -port `<port number>`
+#### --port / -p `<port number>`
 Specifies the port number the VM is awaiting debuggers to connect to
 
-#### -wait `[<timeout>]`
-Indicates to wait for a connection. The timeout is optional and indicates the maximum number of minutes to wait (defaults to 10 minutes).
+#### --wait / -w
+Indicates to wait for a connection. The default timeout is 10 minutes.
 
-#### -continuous
+#### --timeout `<timeout>`
+Specified to change the default timeout when waiting for a connection; it indicates the maximum number of minutes to wait (defaults to 10 minutes).
+
+#### --continuous / -c
 Specifies to run in continuous mode where the debugger will tell the VM not to fail on any security failures detected and report on all failures found.
 
-#### -admin
+#### --admin / -a
 Indicates the tool is being run for an admin. In such cases, the analysis won't be as extensive since an administrator wouldn't be able to modify the code for example.
 At the moment, it disables analyzing solutions that involve extending privileges in bundles using `doPrivileged()` blocks. 
 In the above example, only the second solution would have been reported if this option had been provided. As such, this option should not be used by developers.
 
-#### -dump
-Additional information about detected security failures such as stack traces and bundle information will be dumped along with solutions.
+#### --debug / -d
+Additional information about detected security failures such as stack traces and bundle information will be printed along with solutions.
 
-Here is an example of a dump:
+Here is an example of debug output:
 ```
  0136 - ACCESS CONTROL PERMISSION FAILURE
  ========================================
@@ -335,14 +345,14 @@ As in the context above, a line will show `-->` next to culprit which is respons
 The stack will also show a break line (` ----------------------------------------------------------`) whenever a `doPrivileged()` block is detected. 
 This means that everything after the block is ignored by the security manager.
 
-After having provided information about the current failure, possible options or solutions will be dumped in a similar fashion. 
+After having provided information about the current failure, possible options or solutions will be printed out in a similar fashion. 
 Additional information will be provided to indicate what needs to be done. 
 For example the `Granting permissions to bundles:` section will list a set of bundles that are given the missing permission(s).
 The `Extending privileges at:` section is used to indicate lines in the code where one can introduce a `doPrivileged()` block to solve the issue at hand.
 The stack that will follow will show how it would appear if the option were implemented. There should no longer be any failure; thus, no `-->` will be seen.
 
 The final section will list a summary of all possible solutions. Usually, these are sorted in order of priority but it is still up to the developer to assess which one is better suited in the current context. In the example above, there were 2 solutions.
-This section is the only one that will be printed out on the console when the `-dump` option is not specified.
+This section is the only one that will be printed out on the console when the `--debug` option is not specified.
 
 Here is an example when an acceptable failure is detected:
 ```
@@ -465,11 +475,11 @@ Stack:
 The differences above lie in the permission which is reported as a matching regular expression from the pre-configured acceptable failure definition and in a `#` character seen in the 8th stack line which indicates the line was matched against the same pre-configured acceptable failure definition. 
 Since it is considered an acceptable failure, no solutions section will be printed out.
  
-#### -service
+#### --service
 Specifies that a breakpoint should be added in Eclipse's Service Registry to detect internal security checks done for given bundles before dispatching service events. 
 These failures are analyzed and reported as normal security check failures. This option tends to slow down the system a bit as the debugger is invoked for all checks and not just when a failure is about to be reported.
 
-#### -grant
+#### --grant
 When specified, the debugger will use the backdoor and a registered ServicePermission service to temporarily grant permissions for detected security failures which after analysis yields a single solution. 
 This is only temporary and will not survive a restart of the VM but will prevent any further failures that would otherwise not be if the permission(s) were defined. 
 It also tends to slow down the system since the OSGi permission cache ends up being cleared each time.

--- a/backdoor/pom.xml
+++ b/backdoor/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -41,6 +43,11 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <version>${osgi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>${eclipse-osgi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>

--- a/backdoor/src/main/java/org/codice/acdebugger/backdoor/Backdoor.java
+++ b/backdoor/src/main/java/org/codice/acdebugger/backdoor/Backdoor.java
@@ -18,6 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.Permission;
+import java.security.Permissions;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -34,6 +35,7 @@ import javax.annotation.Nullable;
 import org.codice.acdebugger.PermissionService;
 import org.codice.acdebugger.common.JsonUtils;
 import org.codice.acdebugger.common.ServicePermissionInfo;
+import org.eclipse.osgi.internal.permadmin.BundlePermissions;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -262,7 +264,14 @@ public class Backdoor implements BundleActivator {
    * @return the name/location of the corresponding bundle or <code>null</code> if unable to find it
    */
   @Nullable
+  @SuppressWarnings({
+    "squid:S3776", /* Recursive logic and simple enough to not warrant decomposing more */
+  })
   private String getBundle0(@Nullable Object obj) {
+    // NOTE: The logic here should be kept in sync with the logic in
+    // org.codice.acdebugger.api.BundleUtil
+    String bundle = null;
+
     if (obj == null) {
       return null;
     } else if (obj instanceof Bundle) {
@@ -273,10 +282,17 @@ public class Backdoor implements BundleActivator {
       return ((BundleWiring) obj).getBundle().getSymbolicName();
     } else if (obj instanceof BundleContext) {
       return ((BundleContext) obj).getBundle().getSymbolicName();
-    }
-    // see if it has a getBundle() method
-    String bundle = getBundle0(invoke(obj, "getBundle", Bundle.class));
+    } else if (obj instanceof ProtectionDomain) {
+      // check if we have a protection domain with Eclipse's permissions
+      final Object permissions = invoke(obj, "getPermissions", Permissions.class);
 
+      if (permissions instanceof BundlePermissions) {
+        bundle = getBundle0(permissions);
+      }
+    } // no else here
+    if (bundle == null) { // check if it has a getBundle() method
+      bundle = getBundle0(invoke(obj, "getBundle", Bundle.class));
+    }
     if (bundle == null) { // check if we have a getBundleContext() method
       bundle = getBundle0(invoke(obj, "getBundleContext", BundleContext.class));
     }

--- a/backdoor/src/main/java/org/codice/acdebugger/backdoor/Backdoor.java
+++ b/backdoor/src/main/java/org/codice/acdebugger/backdoor/Backdoor.java
@@ -18,7 +18,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.Permission;
-import java.security.Permissions;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -284,7 +283,7 @@ public class Backdoor implements BundleActivator {
       return ((BundleContext) obj).getBundle().getSymbolicName();
     } else if (obj instanceof ProtectionDomain) {
       // check if we have a protection domain with Eclipse's permissions
-      final Object permissions = invoke(obj, "getPermissions", Permissions.class);
+      final Object permissions = ((ProtectionDomain) obj).getPermissions();
 
       if (permissions instanceof BundlePermissions) {
         bundle = getBundle0(permissions);

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.acdebugger;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -75,37 +88,38 @@ public class ACDebugger implements Callable<Void> {
     description =
         "Specifies the transport to use when connecting to the VM. (default: ${DEFAULT-VALUE})"
   )
-  String transport = "dt_socket";
+  private String transport = "dt_socket";
 
   @Option(
     names = {"-H", "--host"},
     description =
         "Specifies the host or IP where the VM to attach to is located. (default: ${DEFAULT-VALUE})"
   )
-  String host = "localhost";
+  private String host = "localhost";
 
   @Option(
     names = {"-p", "--port"},
     description =
         "Specifies the port number the VM is awaiting debuggers to connect to. (default:${DEFAULT-VALUE})"
   )
-  String port = "5005";
+  private String port = "5005";
 
   @Option(
     names = {"-w", "--wait"},
     description =
         "Indicates to wait for a connection. To specify the timeout value use with the '--wait-timeout' option."
   )
-  boolean wait = false;
+  private boolean wait = false;
 
   @Option(
     names = {"--wait-timeout"},
     description =
         "Only applies when the '--wait' option is used. Sets the maximum number of minutes to wait. (default: ${DEFAULT-VALUE})"
   )
-  long timeout = 10;
+  private long timeout = 10;
 
   @Override
+  @SuppressWarnings("squid:S106" /* this is a console application */)
   public Void call() throws Exception {
 
     final long startTime = System.currentTimeMillis();

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -33,7 +33,6 @@ import picocli.CommandLine.Option;
   versionProvider = PropertiesVersionProvider.class
 )
 public class ACDebugger implements Callable<Void> {
-
   @Option(
     names = {"-a", "--admin"},
     description =
@@ -54,12 +53,12 @@ public class ACDebugger implements Callable<Void> {
   private boolean continuous = false;
 
   @Option(
-    names = {"-d", "--dump"},
+    names = {"-d", "--debug"},
     description =
         "Additional information about detected security failures such as stack traces and bundle information "
             + "will be printed along with solutions."
   )
-  private boolean dumping = false;
+  private boolean debug = false;
 
   @Option(
     names = {"-g", "--grant"},
@@ -107,12 +106,12 @@ public class ACDebugger implements Callable<Void> {
   @Option(
     names = {"-w", "--wait"},
     description =
-        "Indicates to wait for a connection. To specify the timeout value use with the '--wait-timeout' option."
+        "Indicates to wait for a connection. To specify the timeout value use with the '--timeout' option."
   )
   private boolean wait = false;
 
   @Option(
-    names = {"--wait-timeout"},
+    names = {"--timeout"},
     description =
         "Only applies when the '--wait' option is used. Sets the maximum number of minutes to wait. (default: ${DEFAULT-VALUE})"
   )
@@ -141,7 +140,7 @@ public class ACDebugger implements Callable<Void> {
     }
     // configure options
     debugger.setContinuous(continuous);
-    debugger.setDumping(dumping);
+    debugger.setDebug(debug);
     debugger.setGranting(granting);
     debugger.setMonitoringService(service);
     debugger.setDoPrivilegedBlocks(!admin);

--- a/debugger/src/main/java/org/codice/acdebugger/Main.java
+++ b/debugger/src/main/java/org/codice/acdebugger/Main.java
@@ -1,9 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.acdebugger;
 
 import picocli.CommandLine;
 
 public class Main {
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
     CommandLine.call(new ACDebugger(), args);
   }
 }

--- a/debugger/src/main/java/org/codice/acdebugger/api/SecurityFailure.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/SecurityFailure.java
@@ -15,6 +15,7 @@ package org.codice.acdebugger.api;
 
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /** Represents a security failure detected in the attached VM. */
 public interface SecurityFailure {
@@ -24,6 +25,32 @@ public interface SecurityFailure {
    * @return the permissions associated with this security failure
    */
   public Set<String> getPermissions();
+
+  /**
+   * Gets the stack information for this security failure.
+   *
+   * @return the stack information for this security failure
+   */
+  public List<StackFrameInformation> getStack();
+
+  /**
+   * Gets the matched permissions associated with this security failure if it was found to be an
+   * acceptable failure.
+   *
+   * @return the matched permission information if this is an acceptable security failure; otherwise
+   *     <code>null</code>
+   */
+  @Nullable
+  public String getAcceptablePermissions();
+
+  /**
+   * Checks if this failure is an acceptable one for which we shouldn't grant the missing
+   * permissions and simply let the security check fail.
+   *
+   * @return <code>true</code> if this is an acceptable security failure; <code>false</code>
+   *     otherwise
+   */
+  public boolean isAcceptable();
 
   /**
    * Analyze this security failure in order to find solutions.

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
@@ -18,8 +18,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.annotation.Nullable;
 import org.codice.acdebugger.api.SecurityFailure;
 import org.codice.acdebugger.api.SecuritySolution;
+import org.codice.acdebugger.api.StackFrameInformation;
 
 /**
  * This class serves 2 purposes. It is first a representation of a detected security service access
@@ -39,6 +41,22 @@ class SecurityServicePermissionImpliedInformation extends SecuritySolution
   SecurityServicePermissionImpliedInformation(String bundle, Set<String> permissionInfos) {
     super(permissionInfos, Collections.singleton(bundle), Collections.emptyList());
     this.bundle = bundle;
+  }
+
+  @Override
+  public List<StackFrameInformation> getStack() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isAcceptable() {
+    return false; // never acceptable
+  }
+
+  @Nullable
+  @Override
+  public String getAcceptablePermissions() {
+    return null; // never acceptable
   }
 
   @Override

--- a/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
@@ -14,12 +14,12 @@
 package org.codice.acdebugger.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.codice.acdebugger.api.SecurityFailure;
@@ -33,7 +33,7 @@ public class DebugContext {
 
   private final Map<String, Object> map = new ConcurrentHashMap<>();
 
-  private final List<SecurityFailure> failures = Collections.synchronizedList(new ArrayList<>());
+  private final List<SecurityFailure> failures = new ArrayList<>();
 
   private int count = 0;
 
@@ -295,49 +295,84 @@ public class DebugContext {
    *
    * @param failure the security failure to record
    */
-  @SuppressWarnings("squid:S106" /* this is a console application */)
   public void record(SecurityFailure failure) {
     synchronized (failures) {
-      final List<SecuritySolution> solutions = failure.analyze();
-
       failures.add(failure);
-      if (solutions.isEmpty()) { // no solutions so ignore
-        return;
-      }
-      // check to see if we have another recorded failure with the exact same set of solutions
-      if (failures
-          .stream()
-          .filter(i -> i != failure)
-          .map(SecurityFailure::analyze)
-          .anyMatch(solutions::equals)) {
-        return;
-      }
-      if (!continuous) { // stop processing
-        this.run = false;
-      }
-      // check if we have only one solution and that solution is to only grant permission(s)
-      // (no privileged blocks) in which case we shall cache them to avoid going through all
-      // of this again (if not in continuous mode, then we don't really care about that)
-      grantMissingPermissionsIfPossible(solutions);
-      if (dumping) {
-        failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
+      if (failure.isAcceptable()) {
+        recordAcceptableFailure(failure);
       } else {
-        if (continuous) {
-          System.out.printf("%04d - %s {%n", (++count), failure);
-        } else {
-          System.out.printf("%s {%n", failure);
-        }
-        if (solutions.size() > 1) {
-          System.out.println(
-              "    Analyze the following " + solutions.size() + " solutions and choose the best:");
-        } else {
-          System.out.println("    Solution:");
-        }
-        solutions.forEach(s -> s.print("    "));
-        System.out.println("}");
-        if (!continuous) {
-          this.run = false;
-        }
+        recordUnacceptableFailure(failure);
+      }
+    }
+  }
+
+  @SuppressWarnings("squid:S106" /* this is a console application */)
+  private void recordAcceptableFailure(SecurityFailure failure) {
+    // check to see if we have another recorded failure with the exact same reason for being
+    // acceptable in which case we do not want to trace it again
+    if (failures
+        .stream()
+        .filter(i -> i != failure)
+        .filter(SecurityFailure::isAcceptable)
+        .anyMatch(
+            f ->
+                f.getAcceptablePermissions().equals(failure.getAcceptablePermissions())
+                    && f.getStack().equals(failure.getStack()))) {
+      return;
+    }
+    if (dumping) {
+      failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
+    } else {
+      if (continuous) {
+        System.out.printf("%04d - %s {%n", (++count), failure);
+      } else {
+        System.out.printf("%s {%n", failure);
+      }
+      System.out.println("}");
+    }
+  }
+
+  @SuppressWarnings("squid:S106" /* this is a console application */)
+  private void recordUnacceptableFailure(SecurityFailure failure) {
+    final List<SecuritySolution> solutions = failure.analyze();
+
+    if (solutions.isEmpty()) { // no solutions so ignore
+      return;
+    }
+    // check to see if we have another recorded failure with the exact same set of solutions
+    if (failures
+        .stream()
+        .filter(i -> i != failure)
+        .filter(((Predicate<SecurityFailure>) SecurityFailure::isAcceptable).negate())
+        .map(SecurityFailure::analyze)
+        .anyMatch(solutions::equals)) {
+      return;
+    }
+    if (!continuous) { // stop processing
+      this.run = false;
+    }
+    // check if we have only one solution and that solution is to only grant permission(s)
+    // (no privileged blocks) in which case we shall cache them to avoid going through all
+    // of this again (if not in continuous mode, then we don't really care about that)
+    grantMissingPermissionsIfPossible(solutions);
+    if (dumping) {
+      failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
+    } else {
+      if (continuous) {
+        System.out.printf("%04d - %s {%n", (++count), failure);
+      } else {
+        System.out.printf("%s {%n", failure);
+      }
+      if (solutions.size() > 1) {
+        System.out.println(
+            "    Analyze the following " + solutions.size() + " solutions and choose the best:");
+      } else {
+        System.out.println("    Solution:");
+      }
+      solutions.forEach(s -> s.print("    "));
+      System.out.println("}");
+      if (!continuous) {
+        this.run = false;
       }
     }
   }

--- a/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
@@ -43,7 +43,7 @@ public class DebugContext {
 
   private volatile boolean monitoring = false;
 
-  private volatile boolean dumping = false;
+  private volatile boolean debug = false;
 
   private volatile boolean doPrivileged = true;
 
@@ -190,24 +190,24 @@ public class DebugContext {
   }
 
   /**
-   * Checks if the dump mode has been enabled.
+   * Checks if the debug mode has been enabled.
    *
-   * @return <code>true</code> if the debugger will dump security failure information as they are
-   *     detected; <code>false</code> if only solutions are presented on the console
+   * @return <code>true</code> if the debugger will output additional security failure information
+   *     as they are detected; <code>false</code> if only solutions are presented on the console
    */
-  public boolean isDumping() {
-    return dumping;
+  public boolean isDebug() {
+    return debug;
   }
 
   /**
-   * Sets the dump mode where information about security failures detected is dumped to the console
+   * Sets the debug mode where information about security failures detected is dumped to the console
    * in addition to all the solutions.
    *
-   * @param dumping <code>true</code> to enable dumping of security failure information as they are
-   *     detected; <code>false</code> to only preset solutions
+   * @param debug <code>true</code> to enable debug output of security failure information as they
+   *     are detected; <code>false</code> to only preset solutions
    */
-  public void setDumping(boolean dumping) {
-    this.dumping = dumping;
+  public void setDebug(boolean debug) {
+    this.debug = debug;
   }
 
   /**
@@ -320,7 +320,7 @@ public class DebugContext {
                     && f.getStack().equals(failure.getStack()))) {
       return;
     }
-    if (dumping) {
+    if (debug) {
       failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
     } else {
       if (continuous) {
@@ -355,7 +355,7 @@ public class DebugContext {
     // (no privileged blocks) in which case we shall cache them to avoid going through all
     // of this again (if not in continuous mode, then we don't really care about that)
     grantMissingPermissionsIfPossible(solutions);
-    if (dumping) {
+    if (debug) {
       failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
     } else {
       if (continuous) {

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
@@ -96,14 +96,14 @@ public class Debugger {
   }
 
   /**
-   * Sets the dump mode where information about security failures detected is dumped to the console
+   * Sets the debug mode where information about security failures detected is dumped to the console
    * in addition to all the solutions.
    *
-   * @param dumping <code>true</code> to enable dumping of security failure information as they are
-   *     detected; <code>false</code> to only preset solutions
+   * @param debug <code>true</code> to enable debug output of security failure information as they
+   *     are detected; <code>false</code> to only preset solutions
    */
-  public void setDumping(boolean dumping) {
-    context.setDumping(dumping);
+  public void setDebug(boolean debug) {
+    context.setDebug(debug);
   }
 
   /**

--- a/debugger/src/main/resources/acceptable-security-check-failures.txt
+++ b/debugger/src/main/resources/acceptable-security-check-failures.txt
@@ -2,7 +2,7 @@
 # Each entry is defined as consecutive lines separated by a blank line where the first line is a
 # regular expression to match against the permission info string. The remaining lines are regular
 # expressions to match against separate stack lines' location portion only
-# (e.g. <bundle-name>(<location>)) as provided with the --dump option in the same order as listed.
+# (e.g. <bundle-name>(<location>)) as provided with the --debug option in the same order as listed.
 
 # pdfbox actually catches AccessControlException and continue without caching any fonts
 # since DDF doesn't care about the actual fonts as it only processes the metadata from pdf documents

--- a/debugger/src/main/resources/acceptable-security-check-failures.txt
+++ b/debugger/src/main/resources/acceptable-security-check-failures.txt
@@ -1,0 +1,11 @@
+# List of locations and permission checks where it is acceptable to fail
+# Each entry is defined as consecutive lines separated by a blank line where the first line is a
+# regular expression to match against the permission info string. The remaining lines are regular
+# expressions to match against separate stack lines' location portion only
+# (e.g. <bundle-name>(<location>)) as provided with the --dump option in the same order as listed.
+
+# pdfbox actually catches AccessControlException and continue without caching any fonts
+# since DDF doesn't care about the actual fonts as it only processes the metadata from pdf documents
+# we can safely ignore not having access to fonts on the system
+java\.io\.FilePermission ".*", "read"
+org\.apache\.pdfbox\.pdmodel\.font\.FileSystemFontProvider.*

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.codice.acdebugger</groupId>
@@ -37,9 +39,9 @@
 
     <properties>
         <!--  default URL properties -->
-        <codice.scm.connection.url />
-        <snapshots.repository.url />
-        <reports.repository.url />
+        <codice.scm.connection.url/>
+        <snapshots.repository.url/>
+        <reports.repository.url/>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -47,6 +49,7 @@
         <guava.version>23.0</guava.version>
         <boon.version>0.34</boon.version>
         <osgi.version>5.0.0</osgi.version>
+        <eclipse-osgi.version>3.11.3</eclipse-osgi.version>
         <jsr305.version>3.0.2_1</jsr305.version>
         <picocli.version>3.5.2</picocli.version>
         <awaitility.version>3.1.2</awaitility.version>


### PR DESCRIPTION
### Description of the Change
Added support for protection domains defined with a set of bundle permissions.
Enhanced to provide more feedback when unable to determine bundle name at failure location.
Added support for acceptable security failures which are configurable.

### Verification Process
- Start the debugger with the --debug option
- Attempt to ingest a PDF document in DDF and see it reporting acceptable failures to read font files

### Applicable Issues
Fixes: #19, #20, and #21 