### PR TITLE
ACD-31 Checked that --reconnect must be combined with --continuous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ This option is not on by default as it can slow down the system a bit.
 To run the debugger tool, open the debugger project in IDE and run the `org.codice.acdebuger.Main.main()` method. Options can be set in the corresponding IDE `Run/Debug Configuration`.
 
 The maven build can be used to produce an executable jar. The jar can
-be run by doing: `java -jar acdebugger-debugger-1.0-SNAPSHOT-jar-with-dependencies.jar [options]>`
+be run by doing: `java -jar acdebugger-debugger-1.5-jar-with-dependencies.jar [options]>`
 
 ### Typical Output
 ```
-0002 - Check permission failure for platform-migratable-api: java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read" {
-    Analyze the following 2 solutions and choose the best:
-    {
-        Add an AccessController.doPrivileged() block around:
-            platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-    }
-    {
-        Add the following permission to default.policy:
-            grant codeBase "file:/platform-migratable-api" {
-                permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read";
-            }
-    }
-}
+AC Debugger: 0002 - Check permission failure for platform-migratable-api: java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read" {
+AC Debugger:     Analyze the following 2 solutions and choose the best:
+AC Debugger:     {
+AC Debugger:         Add an AccessController.doPrivileged() block around:
+AC Debugger:             platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:     }
+AC Debugger:     {
+AC Debugger:         Add the following permission to default.policy:
+AC Debugger:             grant codeBase "file:/platform-migratable-api" {
+AC Debugger:                 permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read";
+AC Debugger:             }
+AC Debugger:     }
+AC Debugger: }
 ```
 
 The above example is reporting the second analysis solutions block with 2 potential solutions.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As seen in the above example, the analysis gives priority to extending existing 
 ### Options
 The following debugger options are available:
 * --help / -h
+* --version / -V
 * --host / -H `<hostname or IP>`
 * --port / -p `<port number>`
 * --wait / -w
@@ -53,8 +54,6 @@ The following debugger options are available:
 * --service / -s
 * --fail / -f
 * --grant / -g
-* --help / -h
-* --version / -V
 
 #### --help / -h 
 Prints out usage information and exit.
@@ -75,7 +74,7 @@ Indicates to wait for a connection. The default timeout is 10 minutes.
 Specified to change the default timeout when waiting for a connection; it indicates the maximum number of minutes to wait (defaults to 10 minutes).
 
 #### --reconnect / -r
-Indicates to attempt to reconnect automatically after the attached VM has disconnected.
+Indicates to attempt to reconnect automatically after the attached VM has disconnected  (--continuous must also be specified).
 
 #### --continuous / -c
 Specifies to run in continuous mode where the debugger will tell the VM not to fail on any security failures detected (unless --fail is specified) and report on all failures found.

--- a/common/src/main/java/org/codice/acdebugger/common/ServicePermissionInfo.java
+++ b/common/src/main/java/org/codice/acdebugger/common/ServicePermissionInfo.java
@@ -31,7 +31,6 @@ public class ServicePermissionInfo {
    * The {@link java.security.ProtectionDomain#implies(Permission)} result from the requested domain
    * and service permission.
    */
-  @Nullable // only because Boon may not set it as it bypasses our ctor and the final keyword
   private final boolean implies;
 
   /**

--- a/debugger/src/main/java/org/codice/acdebugger/api/SecuritySolution.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/SecuritySolution.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.codice.acdebugger.ACDebugger;
 
 /** Represents a solution to a security failure that was detected while debugging. */
 public class SecuritySolution implements Comparable<SecuritySolution> {
@@ -99,34 +100,46 @@ public class SecuritySolution implements Comparable<SecuritySolution> {
    */
   @SuppressWarnings("squid:S106" /* this is a console application */)
   public void print(String prefix) {
-    System.out.println(prefix + "{");
+    System.out.println(ACDebugger.PREFIX + prefix + "{");
     final String and;
 
     if (!grantedBundles.isEmpty()) {
       final String s = (permissionInfos.size() == 1) ? "" : "s";
 
       System.out.println(
-          prefix + "    Add the following permission" + s + " to the appropriate policy file:");
+          ACDebugger.PREFIX
+              + prefix
+              + "    Add the following permission"
+              + s
+              + " to the appropriate policy file:");
       System.out.println(
-          prefix
+          ACDebugger.PREFIX
+              + prefix
               + "        grant codeBase \"file:/"
               + grantedBundles.stream().sorted().collect(Collectors.joining("/"))
               + "\" {");
       permissionInfos
           .stream()
           .sorted()
-          .forEach(p -> System.out.println(prefix + "            permission " + p + ";"));
-      System.out.println(prefix + "        }");
+          .forEach(
+              p ->
+                  System.out.println(
+                      ACDebugger.PREFIX + prefix + "            permission " + p + ";"));
+      System.out.println(ACDebugger.PREFIX + prefix + "        }");
       and = "and a";
     } else {
       and = "A";
     }
     if (!doPrivileged.isEmpty()) {
       System.out.println(
-          prefix + "    " + and + "dd an AccessController.doPrivileged() block around:");
+          ACDebugger.PREFIX
+              + prefix
+              + "    "
+              + and
+              + "dd an AccessController.doPrivileged() block around:");
       doPrivileged.forEach(f -> System.out.println(prefix + "        " + f));
     }
-    System.out.println(prefix + "}");
+    System.out.println(ACDebugger.PREFIX + prefix + "}");
   }
 
   @Override

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
@@ -22,6 +22,7 @@ import java.security.Permission;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.codice.acdebugger.ACDebugger;
 import org.codice.acdebugger.api.BreakpointProcessor;
 import org.codice.acdebugger.api.Debug;
 import org.codice.acdebugger.impl.BreakpointInfo;
@@ -89,8 +90,9 @@ public class ImpliesBreakpointProcessor implements BreakpointProcessor {
     final StackFrame frame = thread.frame(0);
     final ObjectReference permission = (ObjectReference) frame.getArgumentValues().get(0);
 
-    System.out.println("");
-    System.out.println("PERMISSIONS: " + debug.permissions().getPermissionStrings(permission));
+    System.out.println(ACDebugger.PREFIX);
+    System.out.println(
+        ACDebugger.PREFIX + "PERMISSIONS: " + debug.permissions().getPermissionStrings(permission));
     for (int i = 0; i < debug.thread().frameCount(); i++) {
       final StackFrame f = debug.thread().frame(i);
       final com.sun.jdi.Location location =
@@ -98,7 +100,7 @@ public class ImpliesBreakpointProcessor implements BreakpointProcessor {
       // final String b = debug.getBundle(f);
       // final StackFrameInformation currentFrame = new StackFrameInformation(b, location);
 
-      System.out.println(">>>>>> " + location);
+      System.out.println(ACDebugger.PREFIX + ">>>>>> " + location);
     }
     // force early return as if the domain had permission, that way we simulate no security manager;
     // allowing us to record what is missing while continuing to run

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityCheckInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityCheckInformation.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.codice.acdebugger.ACDebugger;
 import org.codice.acdebugger.api.Debug;
 import org.codice.acdebugger.api.SecurityFailure;
 import org.codice.acdebugger.api.SecuritySolution;
@@ -347,23 +348,27 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
     final String first =
         prefix + (isAcceptable() ? "ACCEPTABLE " : "") + "ACCESS CONTROL PERMISSION FAILURE";
 
-    System.out.println(first);
+    System.out.println(ACDebugger.PREFIX);
+    System.out.println(ACDebugger.PREFIX + first);
     System.out.println(
-        IntStream.range(1, first.length()).mapToObj(i -> "=").collect(Collectors.joining("")));
+        ACDebugger.PREFIX
+            + IntStream.range(0, first.length())
+                .mapToObj(i -> "=")
+                .collect(Collectors.joining("")));
     dump0();
     if (!isAcceptable()) {
       for (int i = 0; i < analysis.size(); i++) {
         final SecuritySolution info = analysis.get(i);
 
-        System.out.println("");
-        System.out.println("OPTION " + (i + 1));
-        System.out.println("--------");
+        System.out.println(ACDebugger.PREFIX);
+        System.out.println(ACDebugger.PREFIX + "OPTION " + (i + 1));
+        System.out.println(ACDebugger.PREFIX + "--------");
         ((SecurityCheckInformation) info).dump0();
       }
       if (!analysis.isEmpty()) {
-        System.out.println("");
-        System.out.println("SOLUTIONS");
-        System.out.println("---------");
+        System.out.println(ACDebugger.PREFIX);
+        System.out.println(ACDebugger.PREFIX + "SOLUTIONS");
+        System.out.println(ACDebugger.PREFIX + "---------");
         analysis.forEach(SecuritySolution::print);
       }
     }
@@ -567,13 +572,13 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
   @SuppressWarnings("squid:S106" /* this is a console application */)
   private void dumpPermission() {
     if (isAcceptable()) {
-      System.out.println("Acceptable permissions:");
-      System.out.println("    " + getAcceptablePermissions());
+      System.out.println(ACDebugger.PREFIX + "Acceptable permissions:");
+      System.out.println(ACDebugger.PREFIX + "    " + getAcceptablePermissions());
     } else {
       final String s = (permissionInfos.size() == 1) ? "" : "s";
 
-      System.out.println("Permission" + s + ":");
-      permissionInfos.forEach(p -> System.out.println("    " + p));
+      System.out.println(ACDebugger.PREFIX + "Permission" + s + ":");
+      permissionInfos.forEach(p -> System.out.println(ACDebugger.PREFIX + "    " + p));
     }
   }
 
@@ -583,24 +588,25 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
       final String bs = (grantedBundles.size() == 1) ? "" : "s";
       final String ps = (permissionInfos.size() == 1) ? "" : "s";
 
-      System.out.println("Granting permission" + ps + " to bundle" + bs + ":");
-      grantedBundles.forEach(d -> System.out.println("    " + d));
+      System.out.println(ACDebugger.PREFIX + "Granting permission" + ps + " to bundle" + bs + ":");
+      grantedBundles.forEach(d -> System.out.println(ACDebugger.PREFIX + "    " + d));
     }
     if (!doPrivileged.isEmpty()) {
-      System.out.println("Extending privileges at:");
-      doPrivileged.forEach(f -> System.out.println("    " + f));
+      System.out.println(ACDebugger.PREFIX + "Extending privileges at:");
+      doPrivileged.forEach(f -> System.out.println(ACDebugger.PREFIX + "    " + f));
     }
   }
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
   private void dumpContext() {
-    System.out.println("Context:");
-    System.out.println("     " + StackFrameInformation.BUNDLE0);
+    System.out.println(ACDebugger.PREFIX + "Context:");
+    System.out.println(ACDebugger.PREFIX + "     " + StackFrameInformation.BUNDLE0);
     for (int i = 0; i < domains.size(); i++) {
       final String domain = domains.get(i);
 
       System.out.println(
-          " "
+          ACDebugger.PREFIX
+              + " "
               + ((i == failedDomainIndex) ? "--> " : "    ")
               + (privilegedDomains.contains(domain) ? "" : "*")
               + domain
@@ -612,16 +618,18 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
   private void dumpStack() {
-    System.out.println("Stack:");
+    System.out.println(ACDebugger.PREFIX + "Stack:");
     for (int i = 0; i < stack.size(); i++) {
       System.out.println(
-          " "
+          ACDebugger.PREFIX
+              + " "
               + ((i == failedStackIndex) ? "-->" : "   ")
               + " at "
               + (isAcceptable() && acceptablePattern.wasMatched(i) ? "#" : "")
               + stack.get(i).toString(privilegedDomains));
       if ((privilegedStackIndex != -1) && (i == privilegedStackIndex)) {
-        System.out.println("    ----------------------------------------------------------");
+        System.out.println(
+            ACDebugger.PREFIX + "    ----------------------------------------------------------");
       }
     }
   }
@@ -636,34 +644,38 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
   private void dumpTroubleshootingInfo(Debug debug, String... msg) {
-    System.err.println(SecurityCheckInformation.DOUBLE_LINES);
-    Stream.of(msg).forEach(System.err::println);
-    System.err.println("PLEASE REPORT AN ISSUE WITH THE FOLLOWING INFORMATION AND INSTRUCTIONS");
+    System.err.println(ACDebugger.PREFIX + SecurityCheckInformation.DOUBLE_LINES);
+    Stream.of(msg).map(ACDebugger.PREFIX::concat).forEach(System.err::println);
+    System.err.println(
+        ACDebugger.PREFIX
+            + "PLEASE REPORT AN ISSUE WITH THE FOLLOWING INFORMATION AND INSTRUCTIONS");
     System.err.println("ON HOW TO REPRODUCE IT");
-    System.err.println(SecurityCheckInformation.DOUBLE_LINES);
-    System.err.println("CURRENT DOMAIN CLASS: " + currentDomain.type().name());
-    System.err.println("CURRENT DOMAIN: " + currentDomain);
-    System.err.println("LOCAL 'i' VARIABLE: " + local_i);
-    System.err.println("ACCESS CONTROL CONTEXT:");
-    context.forEach(b -> System.err.println("  " + b));
-    System.err.println("CONTEXT:");
-    System.err.println("  " + StackFrameInformation.BUNDLE0);
+    System.err.println(ACDebugger.PREFIX + SecurityCheckInformation.DOUBLE_LINES);
+    System.err.println(ACDebugger.PREFIX + "CURRENT DOMAIN CLASS: " + currentDomain.type().name());
+    System.err.println(ACDebugger.PREFIX + "CURRENT DOMAIN: " + currentDomain);
+    System.err.println(ACDebugger.PREFIX + "LOCAL 'i' VARIABLE: " + local_i);
+    System.err.println(ACDebugger.PREFIX + "ACCESS CONTROL CONTEXT:");
+    context.forEach(b -> System.err.println(ACDebugger.PREFIX + "  " + b));
+    System.err.println(ACDebugger.PREFIX + "CONTEXT:");
+    System.err.println(ACDebugger.PREFIX + "  " + StackFrameInformation.BUNDLE0);
     for (int i = 0; i < domains.size(); i++) {
       System.err.print(
-          "  "
+          ACDebugger.PREFIX
+              + "  "
               + domains.get(i)
               + (((i >= combinedDomainsStartIndex) && (combinedDomainsStartIndex != -1))
                   ? " (combined)"
                   : ""));
     }
-    System.err.println("STACK:");
+    System.err.println(ACDebugger.PREFIX + "STACK:");
     for (int i = 0; i < stack.size(); i++) {
-      System.err.println("  at " + stack.get(i));
+      System.err.println(ACDebugger.PREFIX + "  at " + stack.get(i));
       if ((privilegedStackIndex != -1) && (i == privilegedStackIndex)) {
-        System.out.println("    ----------------------------------------------------------");
+        System.out.println(
+            ACDebugger.PREFIX + "    ----------------------------------------------------------");
       }
     }
-    System.err.println(SecurityCheckInformation.DOUBLE_LINES);
+    System.err.println(ACDebugger.PREFIX + SecurityCheckInformation.DOUBLE_LINES);
   }
 
   /** Pattern class for matching specific permission and stack information. */

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
+import org.codice.acdebugger.ACDebugger;
 import org.codice.acdebugger.api.SecurityFailure;
 import org.codice.acdebugger.api.SecuritySolution;
 import org.codice.acdebugger.api.StackFrameInformation;
@@ -69,18 +70,22 @@ class SecurityServicePermissionImpliedInformation extends SecuritySolution
   public void dump(String prefix) {
     final String first = prefix + "IMPLIED PERMISSION FAILURE";
 
-    System.out.println(first);
+    System.out.println(ACDebugger.PREFIX);
+    System.out.println(ACDebugger.PREFIX + first);
     System.out.println(
-        IntStream.range(1, first.length()).mapToObj(i -> "=").collect(Collectors.joining("")));
+        ACDebugger.PREFIX
+            + IntStream.range(0, first.length())
+                .mapToObj(i -> "=")
+                .collect(Collectors.joining("")));
     final String s = (permissionInfos.size() == 1) ? "" : "s";
 
-    System.out.println("Permission" + s + ":");
-    permissionInfos.forEach(p -> System.out.println("    " + p));
-    System.out.println("Granting permission" + s + " to bundle:");
-    System.out.println("    " + bundle);
-    System.out.println("");
-    System.out.println("SOLUTIONS");
-    System.out.println("---------");
+    System.out.println(ACDebugger.PREFIX + "Permission" + s + ":");
+    permissionInfos.forEach(p -> System.out.println(ACDebugger.PREFIX + "    " + p));
+    System.out.println(ACDebugger.PREFIX + "Granting permission" + s + " to bundle:");
+    System.out.println(ACDebugger.PREFIX + "    " + bundle);
+    System.out.println(ACDebugger.PREFIX);
+    System.out.println(ACDebugger.PREFIX + "SOLUTIONS");
+    System.out.println(ACDebugger.PREFIX + "---------");
     print();
   }
 

--- a/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.codice.acdebugger.ACDebugger;
 import org.codice.acdebugger.api.SecurityFailure;
 import org.codice.acdebugger.api.SecuritySolution;
 
@@ -343,14 +344,14 @@ public class DebugContext {
       return;
     }
     if (debug) {
-      failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
+      failure.dump(continuous ? String.format("%04d - ", (++count)) : "");
     } else {
       if (continuous) {
-        System.out.printf("%04d - %s {%n", (++count), failure);
+        System.out.printf("%s%04d - %s {%n", ACDebugger.PREFIX, (++count), failure);
       } else {
-        System.out.printf("%s {%n", failure);
+        System.out.printf("%s%s {%n", ACDebugger.PREFIX, failure);
       }
-      System.out.println("}");
+      System.out.println(ACDebugger.PREFIX + "}");
     }
   }
 
@@ -378,21 +379,24 @@ public class DebugContext {
     // of this again (if not in continuous mode, then we don't really care about that)
     grantMissingPermissionsIfPossible(solutions);
     if (debug) {
-      failure.dump(continuous ? String.format("%n%04d - ", (++count)) : "");
+      failure.dump(continuous ? String.format("%04d - ", (++count)) : "");
     } else {
       if (continuous) {
-        System.out.printf("%04d - %s {%n", (++count), failure);
+        System.out.printf("%s%04d - %s {%n", ACDebugger.PREFIX, (++count), failure);
       } else {
-        System.out.printf("%s {%n", failure);
+        System.out.printf("%s%s {%n", ACDebugger.PREFIX, failure);
       }
       if (solutions.size() > 1) {
         System.out.println(
-            "    Analyze the following " + solutions.size() + " solutions and choose the best:");
+            ACDebugger.PREFIX
+                + "    Analyze the following "
+                + solutions.size()
+                + " solutions and choose the best:");
       } else {
-        System.out.println("    Solution:");
+        System.out.println(ACDebugger.PREFIX + "    Solution:");
       }
       solutions.forEach(s -> s.print("    "));
-      System.out.println("}");
+      System.out.println(ACDebugger.PREFIX + "}");
       if (!continuous) {
         this.run = false;
       }

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
@@ -40,6 +40,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.codice.acdebugger.ACDebugger;
 import org.codice.acdebugger.api.BreakpointProcessor;
 import org.codice.acdebugger.api.Debug;
 
@@ -170,7 +172,12 @@ public class Debugger {
     map.put(HOST_KEY, hostArg);
     this.debug = new DebugImpl(context, connector.attach(map));
     debug.virtualMachine().setDebugTraceMode(VirtualMachine.TRACE_NONE);
-    System.out.printf("AC Debugger: Attached to:%n%s%n%n", debug.virtualMachine().description());
+    System.out.println(ACDebugger.PREFIX + "Attached to:");
+    Stream.of(debug.virtualMachine().description().split("[\r\n]"))
+        .map("  "::concat)
+        .map(ACDebugger.PREFIX::concat)
+        .forEach(System.out::println);
+    System.out.println(ACDebugger.PREFIX);
     return this;
   }
 
@@ -197,7 +204,7 @@ public class Debugger {
   })
   public void loop() throws Exception {
     final EventQueue evtQueue = debug.virtualMachine().eventQueue();
-    String line = "AC Debugger: Monitoring security exceptions";
+    String line = ACDebugger.PREFIX + "Monitoring security exceptions";
 
     if (debug.isMonitoringService()) {
       line += " and service events";
@@ -220,7 +227,7 @@ public class Debugger {
       line += " missing permissions";
     }
     System.out.println(line);
-    System.out.println();
+    System.out.println(ACDebugger.PREFIX);
     while (context.isRunning()) {
       final EventSet eventSet = evtQueue.remove();
       final EventIterator i = eventSet.eventIterator();
@@ -277,8 +284,8 @@ public class Debugger {
       final Event event = i.next();
 
       if (event instanceof VMDisconnectEvent) {
-        System.out.println();
-        System.out.println("AC Debugger: Attached VM has disconnected");
+        System.out.println(ACDebugger.PREFIX);
+        System.out.println(ACDebugger.PREFIX + "Attached VM has disconnected");
         context.stop();
         return true;
       }

--- a/docs/debug.MD
+++ b/docs/debug.MD
@@ -2,254 +2,254 @@
 
 Here is an example of debug output:
 ```
- 0136 - ACCESS CONTROL PERMISSION FAILURE
- ========================================
- Permission:
-     java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
- Context:
-      bundle-0
-      org.apache.commons.io
-  --> *platform-migration
- Stack:
-      at bundle-0(java.security.AccessControlContext:472)
-      at bundle-0(java.security.AccessController:884)
-      at bundle-0(java.lang.SecurityManager:549)
-      at bundle-0(java.lang.SecurityManager:888)
-      at bundle-0(java.io.File:844)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-      at bundle-0(java.io.File:1291)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-  --> at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-     ----------------------------------------------------------
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-      at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-      at bundle-0(java.util.Iterator:116)
-      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-      at bundle-0(java.util.stream.AbstractPipeline:481)
-      at bundle-0(java.util.stream.AbstractPipeline:471)
-      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-      at bundle-0(java.util.stream.AbstractPipeline:234)
-      at bundle-0(java.util.stream.ReferencePipeline:510)
-      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-      at bundle-0(java.util.concurrent.FutureTask:266)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-      at bundle-0(java.lang.Thread:748)
- 
- OPTION 1
- --------
- Permission:
-     java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
- Granting permission to bundles:
-     platform-migration
- Extending privileges at:
-     platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
- Context:
-      bundle-0
-      org.apache.commons.io
-      platform-migration
- Stack:
-      at bundle-0(java.security.AccessControlContext:472)
-      at bundle-0(java.security.AccessController:884)
-      at bundle-0(java.lang.SecurityManager:549)
-      at bundle-0(java.lang.SecurityManager:888)
-      at bundle-0(java.io.File:844)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-      at bundle-0(java.io.File:1291)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction))
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-     ----------------------------------------------------------
-      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-      at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-      at bundle-0(java.util.Iterator:116)
-      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-      at bundle-0(java.util.stream.AbstractPipeline:481)
-      at bundle-0(java.util.stream.AbstractPipeline:471)
-      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-      at bundle-0(java.util.stream.AbstractPipeline:234)
-      at bundle-0(java.util.stream.ReferencePipeline:510)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-      at bundle-0(java.util.concurrent.FutureTask:266)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-      at bundle-0(java.lang.Thread:748)
- 
- OPTION 2
- --------
- Permission:
-     java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
- Granting permission to bundles:
-     platform-migration
-     platform-migratable-api
- Context:
-      bundle-0
-      org.apache.commons.io
-      platform-migration
-      platform-migratable-api
- Stack:
-      at bundle-0(java.security.AccessControlContext:472)
-      at bundle-0(java.security.AccessController:884)
-      at bundle-0(java.lang.SecurityManager:549)
-      at bundle-0(java.lang.SecurityManager:888)
-      at bundle-0(java.io.File:844)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-      at bundle-0(java.io.File:1291)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-      at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-      at platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-     ----------------------------------------------------------
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-      at platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-      at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-      at bundle-0(java.util.Iterator:116)
-      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-      at bundle-0(java.util.stream.AbstractPipeline:481)
-      at bundle-0(java.util.stream.AbstractPipeline:471)
-      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-      at bundle-0(java.util.stream.AbstractPipeline:234)
-      at bundle-0(java.util.stream.ReferencePipeline:510)
-      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-      at bundle-0(java.util.concurrent.FutureTask:266)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-      at bundle-0(java.lang.Thread:748)
- 
- SOLUTIONS
- ---------
- {
-     Add the following permission to the appropriate policy file:
-         grant codeBase "file:/platform-migration" {
-             permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
-         }
-     and add an AccessController.doPrivileged() block around:
-         platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
- }
- {
-     Add the following permission to the appropriate policy file:
-         grant codeBase "file:/platform-migratable-api/platform-migration" {
-             permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
-         }
- }
+AC Debugger: 0136 - ACCESS CONTROL PERMISSION FAILURE
+AC Debugger: ========================================
+AC Debugger: Permission:
+AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
+AC Debugger:  Context:
+AC Debugger:       bundle-0
+AC Debugger:       org.apache.commons.io
+AC Debugger:   --> *platform-migration
+AC Debugger:  Stack:
+AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
+AC Debugger:       at bundle-0(java.security.AccessController:884)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
+AC Debugger:       at bundle-0(java.io.File:844)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
+AC Debugger:       at bundle-0(java.io.File:1291)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
+AC Debugger:   --> at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:      ----------------------------------------------------------
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
+AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
+AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
+AC Debugger:       at bundle-0(java.util.Iterator:116)
+AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
+AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
+AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
+AC Debugger:       at bundle-0(java.lang.Thread:748)
+AC Debugger:  
+AC Debugger:  OPTION 1
+AC Debugger:  --------
+AC Debugger:  Permission:
+AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
+AC Debugger:  Granting permission to bundles:
+AC Debugger:      platform-migration
+AC Debugger:  Extending privileges at:
+AC Debugger:      platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:  Context:
+AC Debugger:       bundle-0
+AC Debugger:       org.apache.commons.io
+AC Debugger:       platform-migration
+AC Debugger:  Stack:
+AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
+AC Debugger:       at bundle-0(java.security.AccessController:884)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
+AC Debugger:       at bundle-0(java.io.File:844)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
+AC Debugger:       at bundle-0(java.io.File:1291)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction))
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:      ----------------------------------------------------------
+AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
+AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
+AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
+AC Debugger:       at bundle-0(java.util.Iterator:116)
+AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
+AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
+AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
+AC Debugger:       at bundle-0(java.lang.Thread:748)
+AC Debugger: 
+AC Debugger:  OPTION 2
+AC Debugger:  --------
+AC Debugger:  Permission:
+AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
+AC Debugger:  Granting permission to bundles:
+AC Debugger:      platform-migration
+AC Debugger:      platform-migratable-api
+AC Debugger:  Context:
+AC Debugger:       bundle-0
+AC Debugger:       org.apache.commons.io
+AC Debugger:       platform-migration
+AC Debugger:       platform-migratable-api
+AC Debugger:  Stack:
+AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
+AC Debugger:       at bundle-0(java.security.AccessController:884)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
+AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
+AC Debugger:       at bundle-0(java.io.File:844)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
+AC Debugger:       at bundle-0(java.io.File:1291)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
+AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:       at platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:      ----------------------------------------------------------
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
+AC Debugger:       at platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
+AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
+AC Debugger:       at bundle-0(java.util.Iterator:116)
+AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
+AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
+AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
+AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
+AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
+AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
+AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
+AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
+AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
+AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
+AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
+AC Debugger:       at bundle-0(java.lang.Thread:748)
+AC Debugger:  
+AC Debugger:  SOLUTIONS
+AC Debugger:  ---------
+AC Debugger:  {
+AC Debugger:      Add the following permission to the appropriate policy file:
+AC Debugger:          grant codeBase "file:/platform-migration" {
+AC Debugger:              permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
+AC Debugger:          }
+AC Debugger:      and add an AccessController.doPrivileged() block around:
+AC Debugger:          platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
+AC Debugger:  }
+AC Debugger:  {
+AC Debugger:      Add the following permission to the appropriate policy file:
+AC Debugger:          grant codeBase "file:/platform-migratable-api/platform-migration" {
+AC Debugger:              permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
+AC Debugger:          }
+AC Debugger:  }
  ```
  
 The first line `0136 - ACCESS CONTROL PERMISSION FAILURE` indicates this was the 136th failure detected and corresponds to an access control permission check. 
@@ -273,120 +273,120 @@ This section is the only one that will be printed out on the console when the `-
 
 Here is an example when an acceptable failure is detected:
 ```
-0141 - ACCEPTABLE ACCESS CONTROL PERMISSION FAILURE
-===================================================
-Acceptable permission:
-    REGEX: java\.io\.FilePermission ".*", "read"
-Context:
-     bundle-0
- --> *org.codice.thirdparty.tika-bundle
-Stack:
-     at bundle-0(java.security.AccessControlContext:472)
-     at bundle-0(java.security.AccessController:884)
-     at bundle-0(java.lang.SecurityManager:549)
-     at bundle-0(java.lang.SecurityManager:888)
-     at bundle-0(java.io.File:814)
- --> at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.NativeFontDirFinder:47)
-     at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.FontFileFinder:75)
-     at #*org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FileSystemFontProvider:214)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl$DefaultFontProvider:130)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:149)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:413)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:376)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:350)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:146)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:79)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:128)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:93)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.PDDocumentCatalog:109)
-     at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:598)
-     at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:545)
-     at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.text.PDFTextStripper:267)
-     at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDF2XHTML:117)
-     at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDFParser:171)
-     at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-     at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-     at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-     at *org.apache.tika.core(org.apache.tika.parser.AutoDetectParser:143)
-     at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:75)
-     at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:68)
-     at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:229)
-     at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:170)
-     at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:153)
-     at *catalog-core-standardframework(ddf.catalog.impl.operations.MetacardFactory:75)
-     at *catalog-core-standardframework(ddf.catalog.impl.operations.OperationsMetacardSupport:156)
-     at *catalog-core-standardframework(ddf.catalog.impl.operations.CreateOperations:141)
-     at *catalog-core-standardframework(ddf.catalog.impl.CatalogFrameworkImpl:237)
-     at *catalog-rest-impl(Proxy657df4cb_72a9_4651_97be_9316fe1dabb9.create(ddf.catalog.content.operation.CreateStorageRequest)+58)
-     at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:764)
-     at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:727)
-     at *catalog-ui-search(Proxye57e7ff3_143d_40a0_beef_f9bad6b72587.addDocument(java.util.List, javax.servlet.http.HttpServletRequest, java.lang.String, java.io.InputStream)+77)
-     at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:375)
-     at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:150)
-     at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication$$Lambda$808.525212850.handle(spark.Request, spark.Response)+6)
-     at *catalog-ui-search(spark.RouteImpl$1:61)
-     at *catalog-ui-search(spark.http.matching.Routes:61)
-     at *catalog-ui-search(spark.http.matching.MatcherFilter:130)
-     at *catalog-ui-search(org.codice.ddf.catalog.ui.SparkServlet:146)
-     at *javax.servlet-api(javax.servlet.http.HttpServlet:790)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHolder:840)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1772)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:98)
-     at *platform-filter-clientinfo(org.codice.ddf.platform.filter.clientinfo.ClientInfoFilter:72)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *platform-filter-response(org.codice.ddf.platform.response.filter.ResponseFilter:96)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *security-filter-authorization(org.codice.ddf.security.filter.authorization.AuthorizationFilter:103)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:271)
-     at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$531.1165582791.run()+12)
-     at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction, java.security.AccessControlContext)+-1)
-     at bundle-0(javax.security.auth.Subject:422)
-    ----------------------------------------------------------
-     at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:281)
-     at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$530.644881876.call()+16)
-     at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-     at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-     at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-     at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:267)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:229)
-     at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:122)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *security-filter-csrf(org.codice.ddf.security.filter.csrf.CsrfFilter:146)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-     at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.DelegateServletFilter:119)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
-     at *org.eclipse.jetty.websocket.server(org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter:205)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:582)
-     at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler:71)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:143)
-     at *org.eclipse.jetty.security(org.eclipse.jetty.security.SecurityHandler:548)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:226)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1180)
-     at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceContext:296)
-     at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:512)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:185)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1112)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:141)
-     at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection:80)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.HandlerWrapper:134)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.Server:539)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpChannel:333)
-     at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpConnection:251)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.ssl.SslConnection:251)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
-     at *org.eclipse.jetty.io(org.eclipse.jetty.io.SelectChannelEndPoint$2:93)
-     at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:303)
-     at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:148)
-     at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:136)
-     at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool:671)
-     at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool$2:589)
-     at bundle-0(java.lang.Thread:748)
+AC Debugger: 0141 - ACCEPTABLE ACCESS CONTROL PERMISSION FAILURE
+AC Debugger: ===================================================
+AC Debugger: Acceptable permission:
+AC Debugger:     REGEX: java\.io\.FilePermission ".*", "read"
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:  --> *org.codice.thirdparty.tika-bundle
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472)
+AC Debugger:      at bundle-0(java.security.AccessController:884)
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549)
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888)
+AC Debugger:      at bundle-0(java.io.File:814)
+AC Debugger:  --> at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.NativeFontDirFinder:47)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.FontFileFinder:75)
+AC Debugger:      at #*org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FileSystemFontProvider:214)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl$DefaultFontProvider:130)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:149)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:413)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:376)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:350)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:146)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:79)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:128)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:93)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.PDDocumentCatalog:109)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:598)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:545)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.text.PDFTextStripper:267)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDF2XHTML:117)
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDFParser:171)
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.AutoDetectParser:143)
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:75)
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:68)
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:229)
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:170)
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:153)
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.MetacardFactory:75)
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.OperationsMetacardSupport:156)
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.CreateOperations:141)
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.CatalogFrameworkImpl:237)
+AC Debugger:      at *catalog-rest-impl(Proxy657df4cb_72a9_4651_97be_9316fe1dabb9.create(ddf.catalog.content.operation.CreateStorageRequest)+58)
+AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:764)
+AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:727)
+AC Debugger:      at *catalog-ui-search(Proxye57e7ff3_143d_40a0_beef_f9bad6b72587.addDocument(java.util.List, javax.servlet.http.HttpServletRequest, java.lang.String, java.io.InputStream)+77)
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:375)
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:150)
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication$$Lambda$808.525212850.handle(spark.Request, spark.Response)+6)
+AC Debugger:      at *catalog-ui-search(spark.RouteImpl$1:61)
+AC Debugger:      at *catalog-ui-search(spark.http.matching.Routes:61)
+AC Debugger:      at *catalog-ui-search(spark.http.matching.MatcherFilter:130)
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.SparkServlet:146)
+AC Debugger:      at *javax.servlet-api(javax.servlet.http.HttpServlet:790)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHolder:840)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1772)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:98)
+AC Debugger:      at *platform-filter-clientinfo(org.codice.ddf.platform.filter.clientinfo.ClientInfoFilter:72)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *platform-filter-response(org.codice.ddf.platform.response.filter.ResponseFilter:96)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *security-filter-authorization(org.codice.ddf.security.filter.authorization.AuthorizationFilter:103)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:271)
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$531.1165582791.run()+12)
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction, java.security.AccessControlContext)+-1)
+AC Debugger:      at bundle-0(javax.security.auth.Subject:422)
+AC Debugger:     ----------------------------------------------------------
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:281)
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$530.644881876.call()+16)
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:267)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:229)
+AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:122)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *security-filter-csrf(org.codice.ddf.security.filter.csrf.CsrfFilter:146)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.DelegateServletFilter:119)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
+AC Debugger:      at *org.eclipse.jetty.websocket.server(org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter:205)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:582)
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler:71)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:143)
+AC Debugger:      at *org.eclipse.jetty.security(org.eclipse.jetty.security.SecurityHandler:548)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:226)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1180)
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceContext:296)
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:512)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:185)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1112)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:141)
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection:80)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.HandlerWrapper:134)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.Server:539)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpChannel:333)
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpConnection:251)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.ssl.SslConnection:251)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.SelectChannelEndPoint$2:93)
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:303)
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:148)
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:136)
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool:671)
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool$2:589)
+AC Debugger:      at bundle-0(java.lang.Thread:748)
 ```
 
 The differences above lie in the permission which is reported as a matching regular expression from the pre-configured acceptable failure definition and in a `#` character seen in the 8th stack line which indicates the line was matched against the same pre-configured acceptable failure definition. 
@@ -394,44 +394,44 @@ Since it is considered an acceptable failure, no solutions section will be print
  
 Here is another example illustration a scenario where a combined access control context is in play within the security manager:
 ```
-0001 - ACCESS CONTROL PERMISSION FAILURE
-========================================
-Permission:
-    java.io.FilePermission "${/}ingest${/}metacard.xml", "read"
-Context:
-     bundle-0
-     catalog-core-commands
-     org.apache.shiro.core
-     org.apache.karaf.shell.core
- --> *org.apache.karaf.shell.ssh (combined)
-     *org.apache.sshd.core (combined)
-Stack:
-     at bundle-0(java.security.AccessControlContext:472)
-     at bundle-0(java.security.AccessController:884)
-     at bundle-0(java.lang.SecurityManager:549)
-     at bundle-0(java.lang.SecurityManager:888)
-     at bundle-0(java.io.File:814)
-     at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:353)
-     at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:249)
-     at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$980.479024148.call()+4)
-     at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-     at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-     at org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-     at catalog-core-commands(org.codice.ddf.security.common.Security:182)
-     at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands:88)
-     at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-     at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-     at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-     at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-     at bundle-0(java.util.concurrent.FutureTask:266)
-     at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-     at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-     at bundle-0(java.lang.Thread:748)
+AC Debugger: 0001 - ACCESS CONTROL PERMISSION FAILURE
+AC Debugger: ========================================
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${/}ingest${/}metacard.xml", "read"
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:      catalog-core-commands
+AC Debugger:      org.apache.shiro.core
+AC Debugger:      org.apache.karaf.shell.core
+AC Debugger:  --> *org.apache.karaf.shell.ssh (combined)
+AC Debugger:      *org.apache.sshd.core (combined)
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472)
+AC Debugger:      at bundle-0(java.security.AccessController:884)
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549)
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888)
+AC Debugger:      at bundle-0(java.io.File:814)
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:353)
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:249)
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$980.479024148.call()+4)
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
+AC Debugger:      at catalog-core-commands(org.codice.ddf.security.common.Security:182)
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands:88)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266)
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
+AC Debugger:      at bundle-0(java.lang.Thread:748)
 ```
 
 In such scenario, the access control context used by the security manager to verify permissions is composed of two parts: the first (as seen in other examples) comes from the current stack and the second part is inherited via a combined access control context. 


### PR DESCRIPTION
### Description of the Change
Checked that --reconnect must be combined with --continuous.
Prefixed all output lines with 'ACD Debugger: ' such that they would be more visible during itests.
Fix readme duplication.

### Verification Process
- debug a security exception and ensure the output lines are all prefixed
- attempt to use --reconnect without --continuous

### Applicable Issues
Fixes: #31 