### PR TITLE
ACD-33 Replaced Boon with Gson

### DIFF
--- a/backdoor/pom.xml
+++ b/backdoor/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -46,12 +48,8 @@
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.fastjson</groupId>
-            <artifactId>boon</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
         </dependency>
     </dependencies>
 
@@ -66,12 +64,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Vendor>Codice</Bundle-Vendor>
                         <Bundle-Activator>org.codice.acdebugger.backdoor.Backdoor</Bundle-Activator>
-                        <Embed-Dependency>acdebugger-common, boon</Embed-Dependency>
-                        <Import-Package> <!-- imports specific as optional for embedding boon -->
-                            com.sun.management;resolution:=optional,
-                            sun.misc;resolution:=optional,
-                            *
-                        </Import-Package>
+                        <Embed-Dependency>acdebugger-common, gson</Embed-Dependency>
                         <Require-Capability>
                             osgi.service;filter:="(objectClass=org.codice.acdebugger.PermissionService)";effective:=active;resolution:=optional
                         </Require-Capability>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -32,8 +34,8 @@
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.fastjson</groupId>
-            <artifactId>boon</artifactId>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/codice/acdebugger/common/JsonUtils.java
+++ b/common/src/main/java/org/codice/acdebugger/common/JsonUtils.java
@@ -13,12 +13,8 @@
  */
 package org.codice.acdebugger.common;
 
-import java.lang.reflect.InvocationTargetException;
-import org.boon.Exceptions.SoftenedException;
-import org.boon.json.JsonFactory;
-import org.boon.json.JsonParserFactory;
-import org.boon.json.JsonSerializerFactory;
-import org.boon.json.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /** Provides useful functions for dealing with Json. */
 public class JsonUtils {
@@ -26,43 +22,13 @@ public class JsonUtils {
     throw new UnsupportedOperationException();
   }
 
-  private static final ObjectMapper MAPPER =
-      JsonFactory.create(
-          new JsonParserFactory().useAnnotations(),
-          new JsonSerializerFactory()
-              .useAnnotations()
-              .includeDefaultValues()
-              .includeEmpty()
-              .includeBlank()
-              .includeNulls());
+  private static final Gson GSON = new GsonBuilder().serializeNulls().create();
 
   public static String toJson(Object value) {
-    return JsonUtils.MAPPER.toJson(value);
+    return JsonUtils.GSON.toJson(value);
   }
 
-  // FYI, Boon has a bug when dealing with streams where it stops reading the stream at whatever is
-  // returned from the first read with a buffer of 8K. If the stream returns less or 8K, the stream
-  // is closed. So if you are dealing with large Json files, that chops the file.
-  // See https://github.com/boonproject/boon/issues/320 describes the problem
-  // if you follow the suggested instructions then it stops at 1K and never goes back.
   public static <T> T fromJson(String json, Class<T> clazz) {
-    try {
-      return JsonUtils.MAPPER.fromJson(json, clazz);
-    } catch (SoftenedException e) {
-      JsonUtils.handleException(e);
-      throw e;
-    }
-  }
-
-  private static void handleException(Throwable t) {
-    if (t instanceof SoftenedException) {
-      JsonUtils.handleException(t.getCause());
-    } else if (t instanceof InvocationTargetException) {
-      JsonUtils.handleException(t.getCause());
-    } else if (t instanceof Error) {
-      throw (Error) t;
-    } else if (t instanceof RuntimeException) {
-      throw (RuntimeException) t;
-    } // else - Let the calling code above deal with throwing the original exception
+    return JsonUtils.GSON.fromJson(json, clazz);
   }
 }

--- a/common/src/main/java/org/codice/acdebugger/common/ServicePermissionInfo.java
+++ b/common/src/main/java/org/codice/acdebugger/common/ServicePermissionInfo.java
@@ -15,6 +15,7 @@ package org.codice.acdebugger.common;
 
 import java.security.Permission;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -24,27 +25,27 @@ public class ServicePermissionInfo {
    * Set of permission strings corresponding to the service permission this information was created
    * for.
    */
-  @Nullable // only because Boon may not set it as it bypasses our ctor and the final keyword
-  private final Set<String> permissionStrings;
+  @Nullable // only because Gson may set it to null
+  private Set<String> permissionStrings;
 
   /**
    * The {@link java.security.ProtectionDomain#implies(Permission)} result from the requested domain
    * and service permission.
    */
-  private final boolean implies;
+  private boolean implies;
 
   /**
    * A set of permission strings corresponding to the given permission which were individually
    * checked using {@link java.security.ProtectionDomain#implies(Permission)} and returned <code>
    * true</code>.
    */
-  @Nullable // only because Boon may not set it as it bypasses our ctor and the final keyword
-  private final Set<String> implied;
+  @Nullable // only because Gson may set it to null
+  private Set<String> implied;
 
   public ServicePermissionInfo() {
-    this.permissionStrings = Collections.emptySet();
+    this.permissionStrings = new HashSet<>(4);
     this.implies = false;
-    this.implied = Collections.emptySet();
+    this.implied = new HashSet<>(8);
   }
 
   public ServicePermissionInfo(

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.codice.acdebugger</groupId>
@@ -46,7 +48,7 @@
 
 
         <guava.version>23.0</guava.version>
-        <boon.version>0.34</boon.version>
+        <gson.version>2.8.5</gson.version>
         <osgi.version>5.0.0</osgi.version>
         <jsr305.version>3.0.2_1</jsr305.version>
         <picocli.version>3.5.2</picocli.version>
@@ -106,9 +108,9 @@
                 <version>${osgi.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.fastjson</groupId>
-                <artifactId>boon</artifactId>
-                <version>${boon.version}</version>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun</groupId>


### PR DESCRIPTION
### Description of the Change
Replaces Boon with Gson in preparation of Java 11.

### Alternate Designs
Use Jackson instead of Gson

### Benefits
Faster

### Possible Drawbacks
Larger and speed is not really a requirement here

### Verification Process
- rebuild this PR
- update DDF main pom to temporarily point to this version of the AC debugger
- rebuild the distro
- remove some permission in the policy file
- start DDF and start the debugger
- run through a scenario involving the removed permission

### Applicable Issues
Fixes: #33 