### PR TITLE
[J11] ACD-36 Added support for non-OSGi VM and sanitize for Java 11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,33 @@ The maven build can be used to produce an executable jar. The jar can
 be run by doing: `java -jar acdebugger-debugger-1.5-jar-with-dependencies.jar [options]>`
 
 ### Typical Output
+For OSGi containers, the typical output will be:
 ```
-AC Debugger: 0002 - Check permission failure for platform-migratable-api: java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read" {
+AC Debugger: 0002 - Check permission failure for platform-migratable-api: java.io.FilePermission "${ddf.home.perm}security${/}configurations.policy", "read" {
 AC Debugger:     Analyze the following 2 solutions and choose the best:
 AC Debugger:     {
 AC Debugger:         Add an AccessController.doPrivileged() block around:
 AC Debugger:             platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
 AC Debugger:     }
 AC Debugger:     {
-AC Debugger:         Add the following permission to default.policy:
+AC Debugger:         Add the following permission block to default.policy:
 AC Debugger:             grant codeBase "file:/platform-migratable-api" {
-AC Debugger:                 permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/configurations.policy", "read";
+AC Debugger:                 permission java.io.FilePermission "${ddf.home.perm}security${/}configurations.policy", "read";
 AC Debugger:             }
 AC Debugger:     }
+AC Debugger: }
+```
+
+For non-OSGi containers, the typical output will be:
+```
+AC Debugger: 0002 - Check permission failure for platform-migratable-api: java.io.FilePermission "${solr.solr.home}${/}server${/}modules", "read" {
+AC Debugger:     Add the following permission blocks to the appropriate policy file:
+AC Debugger:         grant codeBase "file:${solr.solr.home}${/}server${/}security${/}pro-grade-1.1.3.jar" {
+AC Debugger:             permission java.io.FilePermission "${solr.solr.home}${/}server${/}modules", "read";
+AC Debugger:         }
+AC Debugger:         grant codeBase "file:${solr.solr.home}${/}server${/}server${/}start.jar" {
+AC Debugger:             permission java.io.FilePermission "${solr.solr.home}${/}server${/}modules", "read";
+AC Debugger:         }
 AC Debugger: }
 ```
 
@@ -54,6 +68,7 @@ The following debugger options are available:
 * --service / -s
 * --fail / -f
 * --grant / -g
+* --osgi=`<osgi>`
 
 #### --help / -h 
 Prints out usage information and exit.
@@ -101,6 +116,10 @@ When specified, the debugger will use the backdoor and a registered ServicePermi
 This is only temporary and will not survive a restart of the VM but will prevent any further failures that would otherwise not be if the permission(s) were defined. 
 It also tends to slow down the system since the OSGi permission cache ends up being cleared each time.
 
+#### --osgi=`<osgi>`
+Indicates the VM we are able to debug is an OSGi container. (default: true)
+When debugging a non-OSGi container, the debugger will report the codesource location of domains instead of bundle names. 
+ 
 ### Modules
 The following modules are defined:
 * acdebugger-api

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Access Controller Debugger
-Purpose-built debugger for determining missing OSGi bundle security permissions.
+Purpose-built debugger for determining missing security permissions in OSGi containers and non-OSGi VM.
 
 ### Current implementation
 The current implementation will put a breakpoint on line 472 of

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Prints out usage information and exit.
 Prints version information and exit.
 
 #### --host / -H `<hostname or IP>`
-Specifies the host or IP where the VM to attach to is located
+Specifies the host or IP where the VM to attach to is located (defaults to `localhost`).
  
 #### --port / -p `<port number>`
-Specifies the port number the VM is awaiting debuggers to connect to
+Specifies the port number the VM is awaiting debuggers to connect to (defaults to `5005`).
 
 #### --wait / -w
 Indicates to wait for a connection. The default timeout is 10 minutes.

--- a/api/src/main/java/org/codice/acdebugger/PermissionService.java
+++ b/api/src/main/java/org/codice/acdebugger/PermissionService.java
@@ -16,13 +16,13 @@ package org.codice.acdebugger;
 /** Service used for dynamically granting permissions. */
 public interface PermissionService {
   /**
-   * Grants the specified permission to the specified bundle.
+   * Grants the specified permission to the specified domain.
    *
-   * @param bundle the bundle name/location to whom the permission should be granted
+   * @param domain the bundle name or domain location to whom the permission should be granted
    * @param permission the permission to be granted in a standard policy format string
    *     representation
    * @throws Exception if a failure occurs while granting the given permission
    */
   @SuppressWarnings("squid:S00112" /* Interface used during debugging and meant to be generic */)
-  public void grantPermission(String bundle, String permission) throws Exception;
+  public void grantPermission(String domain, String permission) throws Exception;
 }

--- a/common/src/main/java/org/codice/acdebugger/common/DomainInfo.java
+++ b/common/src/main/java/org/codice/acdebugger/common/DomainInfo.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.common;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.ProtectionDomain;
+import javax.annotation.Nullable;
+
+/** Defines a Json object to represent domain information. */
+public class DomainInfo {
+  /**
+   * The location from the codebase of the domain as a string (see {@link
+   * ProtectionDomain#getCodeSource()} and {@link CodeSource#getLocation()}).
+   */
+  @Nullable private String locationString;
+
+  /**
+   * The {@link java.security.ProtectionDomain#implies(Permission)} result from the requested domain
+   * and permission.
+   */
+  private boolean implies;
+
+  public DomainInfo() {
+    this.locationString = null;
+    this.implies = false;
+  }
+
+  public DomainInfo(ProtectionDomain domain, Permission permission) {
+    final CodeSource src = domain.getCodeSource();
+    final URL url = (src != null) ? src.getLocation() : null;
+
+    this.locationString = (url != null) ? url.toString() : null;
+    this.implies = domain.implies(permission);
+  }
+
+  public DomainInfo(String locationString, boolean implies) {
+    this.locationString = locationString;
+    this.implies = implies;
+  }
+
+  @Nullable
+  public String getLocationString() {
+    return locationString;
+  }
+
+  public boolean implies() {
+    return implies;
+  }
+}

--- a/common/src/main/java/org/codice/acdebugger/common/JsonUtils.java
+++ b/common/src/main/java/org/codice/acdebugger/common/JsonUtils.java
@@ -15,6 +15,7 @@ package org.codice.acdebugger.common;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.lang.reflect.Type;
 
 /** Provides useful functions for dealing with Json. */
 public class JsonUtils {
@@ -30,5 +31,9 @@ public class JsonUtils {
 
   public static <T> T fromJson(String json, Class<T> clazz) {
     return JsonUtils.GSON.fromJson(json, clazz);
+  }
+
+  public static <T> T fromJson(String json, Type type) {
+    return JsonUtils.GSON.fromJson(json, type);
   }
 }

--- a/common/src/main/java/org/codice/acdebugger/common/PermissionUtil.java
+++ b/common/src/main/java/org/codice/acdebugger/common/PermissionUtil.java
@@ -18,6 +18,10 @@ import javax.annotation.Nullable;
 
 /** Provides permission-specific functionality. */
 public class PermissionUtil {
+  private PermissionUtil() {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Gets a permission string compatible with the policy file format based on the given policy
    * class, name and actions.

--- a/common/src/main/java/org/codice/acdebugger/common/PropertiesUtil.java
+++ b/common/src/main/java/org/codice/acdebugger/common/PropertiesUtil.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.common;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Utility classes for compressing strings based on system property values with special <code>
+ * ${property.name}</code> strings.
+ */
+public class PropertiesUtil {
+  public static final List<String> PROPERTIES =
+      Resources.readLines(PropertiesUtil.class, "properties.txt");
+
+  private final Properties properties;
+
+  /**
+   * Builds a property utility with the given set of system property mappings.
+   *
+   * @param properties the set of property names/values to use when contracting
+   */
+  public PropertiesUtil(Properties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Compresses the specified strings by replacing occurrences of configured system properties.
+   *
+   * @param s the string to compress
+   * @return the corresponding compressed string
+   */
+  public String compress(String s) {
+    for (final String property : PropertiesUtil.PROPERTIES) {
+      s = replaceWithProperty(s, property);
+    }
+    return s;
+  }
+
+  private String replaceWithProperty(String s, String property) {
+    final String value = properties.getProperty(property);
+
+    if ((value != null) && !value.isEmpty()) {
+      return s.replace(value, "${" + property + "}");
+    }
+    return s;
+  }
+}

--- a/common/src/main/java/org/codice/acdebugger/common/PropertiesUtil.java
+++ b/common/src/main/java/org/codice/acdebugger/common/PropertiesUtil.java
@@ -15,16 +15,17 @@ package org.codice.acdebugger.common;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 /**
  * Utility classes for compressing strings based on system property values with special <code>
  * ${property.name}</code> strings.
  */
 public class PropertiesUtil {
-  public static final List<String> PROPERTIES =
+  private static final List<String> PROPERTIES =
       Resources.readLines(PropertiesUtil.class, "properties.txt");
 
-  private final Properties properties;
+  private final Properties systemProperties;
 
   /**
    * Builds a property utility with the given set of system property mappings.
@@ -32,7 +33,7 @@ public class PropertiesUtil {
    * @param properties the set of property names/values to use when contracting
    */
   public PropertiesUtil(Properties properties) {
-    this.properties = properties;
+    this.systemProperties = properties;
   }
 
   /**
@@ -49,11 +50,20 @@ public class PropertiesUtil {
   }
 
   private String replaceWithProperty(String s, String property) {
-    final String value = properties.getProperty(property);
+    final String value = systemProperties.getProperty(property);
 
     if ((value != null) && !value.isEmpty()) {
       return s.replace(value, "${" + property + "}");
     }
     return s;
+  }
+
+  /**
+   * Gets all configurated system property names.
+   *
+   * @return a stream of all configured property names
+   */
+  public static Stream<String> propertiesNames() {
+    return PropertiesUtil.PROPERTIES.stream();
   }
 }

--- a/common/src/main/java/org/codice/acdebugger/common/Resources.java
+++ b/common/src/main/java/org/codice/acdebugger/common/Resources.java
@@ -14,6 +14,7 @@
 package org.codice.acdebugger.common;
 
 import java.io.BufferedReader;
+import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -25,12 +26,17 @@ import java.util.function.Function;
 
 /** Utility classes for managing resources. */
 public class Resources {
+  private Resources() {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Reads a list of lines from the specified resource relative to the given class.
    *
    * @param clazz the class relative to where the resource should be loaded
    * @param name the name of the resource to load
    * @return an unmodifiable list of all trimmed lines read from the resource
+   * @throws IOError if an I/O exception occurs
    */
   public static List<String> readLines(Class<?> clazz, String name) {
     return Resources.readLines(clazz, name, Function.identity());
@@ -43,6 +49,7 @@ public class Resources {
    * @param name the name of the resource to load
    * @param transformer a function to convert each trimmed lines into the required object
    * @return an unmodifiable list of all transformed lines read from the resource
+   * @throws IOError if an I/O exception occurs
    */
   public static <T> List<T> readLines(
       Class<?> clazz, String name, Function<String, T> transformer) {
@@ -62,7 +69,7 @@ public class Resources {
       }
       return Collections.unmodifiableList(lines);
     } catch (IOException e) {
-      throw new Error(e);
+      throw new IOError(e);
     }
   }
 }

--- a/common/src/main/java/org/codice/acdebugger/common/Resources.java
+++ b/common/src/main/java/org/codice/acdebugger/common/Resources.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.common;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/** Utility classes for managing resources. */
+public class Resources {
+  /**
+   * Reads a list of lines from the specified resource relative to the given class.
+   *
+   * @param clazz the class relative to where the resource should be loaded
+   * @param name the name of the resource to load
+   * @return an unmodifiable list of all trimmed lines read from the resource
+   */
+  public static List<String> readLines(Class<?> clazz, String name) {
+    return Resources.readLines(clazz, name, Function.identity());
+  }
+
+  /**
+   * Reads a list of lines from the specified resource relative to the given class.
+   *
+   * @param clazz the class relative to where the resource should be loaded
+   * @param name the name of the resource to load
+   * @param transformer a function to convert each trimmed lines into the required object
+   * @return an unmodifiable list of all transformed lines read from the resource
+   */
+  public static <T> List<T> readLines(
+      Class<?> clazz, String name, Function<String, T> transformer) {
+    final List<T> lines = new ArrayList<>();
+
+    try (final InputStream is = clazz.getResourceAsStream('/' + name);
+        final Reader r = new InputStreamReader(is);
+        final BufferedReader br = new BufferedReader(r)) {
+      String line;
+
+      while ((line = br.readLine()) != null) {
+        final String trimmed = line.trim();
+
+        if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+          lines.add(transformer.apply(trimmed));
+        }
+      }
+      return Collections.unmodifiableList(lines);
+    } catch (IOException e) {
+      throw new Error(e);
+    }
+  }
+}

--- a/common/src/main/resources/properties.txt
+++ b/common/src/main/resources/properties.txt
@@ -1,0 +1,12 @@
+# Ordered lists of system properties to expand for file permission names
+# and file-based domain locations.
+
+solr.ssl.keystore
+solr.ssl.truststore
+java.io.tmpdir
+java.home
+ddf.home.perm
+ddf.home
+solr.home
+solr.solr.home
+/

--- a/debugger/src/main/java/org/codice/acdebugger/Main.java
+++ b/debugger/src/main/java/org/codice/acdebugger/Main.java
@@ -15,6 +15,7 @@ package org.codice.acdebugger;
 
 import picocli.CommandLine;
 
+/** Main point of entry for the debugger. */
 public class Main {
   public static void main(String[] args) {
     CommandLine.call(new ACDebugger(), args);

--- a/debugger/src/main/java/org/codice/acdebugger/api/BreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/BreakpointProcessor.java
@@ -13,7 +13,9 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.request.EventRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.request.EventRequest; // NOSONAR
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.codice.acdebugger.impl.BreakpointInfo;
@@ -24,7 +26,6 @@ import org.codice.acdebugger.impl.BreakpointLocation;
  * want to be called for and are then consulted to create requests with the debugger and finally
  * consulted to process the debugging callback.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public interface BreakpointProcessor {
   /**
    * Creates a location for anywhere in a given class.

--- a/debugger/src/main/java/org/codice/acdebugger/api/BundleUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/BundleUtil.java
@@ -13,18 +13,17 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ClassObjectReference;
-import com.sun.jdi.Method;
 import com.sun.jdi.ObjectReference;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.StackFrame;
+import com.sun.jdi.Value;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 /** Provides bundle utility functionality. */
 @SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
-public class BundleUtil {
+public class BundleUtil implements LocationUtil {
   /** Internal key where bundle names for specific objects are cached. */
   private static final String BUNDLE_INFO_CACHE = "debug.bundle.info.cache";
 
@@ -42,6 +41,18 @@ public class BundleUtil {
     this.debug = debug;
   }
 
+  @Nullable
+  @Override
+  public String get(@Nullable Value domain) {
+    return get((Object) domain);
+  }
+
+  @Override
+  @Nullable
+  public String get(StackFrame frame) {
+    return get((Object) frame);
+  }
+
   /**
    * Gets a bundle location for the given object. The object can be a {@link StackFrame} or an
    * {@link ObjectReference} representing a bundle, a protection domain, a bundle context, or even a
@@ -56,7 +67,7 @@ public class BundleUtil {
     if (obj == null) {
       return null;
     }
-    final String bundle = get0(obj);
+    final String bundle = get0(debug.reflection(), obj);
 
     return (bundle != BundleUtil.NULL_BUNDLE) ? bundle : null; // identity check here
   }
@@ -68,9 +79,12 @@ public class BundleUtil {
   })
   private String getFromBackdoor(Object obj, Map<Object, String> cache) {
     try {
-      final String bundle = debug.backdoor().getBundle(debug, obj);
+      String bundle = debug.backdoor().getBundle(debug, obj);
 
-      cache.put(obj, (bundle != null) ? bundle : BundleUtil.NULL_BUNDLE);
+      if (bundle == null) {
+        bundle = BundleUtil.NULL_BUNDLE;
+      }
+      cache.put(obj, bundle);
       return bundle;
     } catch (VirtualMachineError e) {
       throw e;
@@ -88,6 +102,7 @@ public class BundleUtil {
    * classloader. This methods makes all attempts possible to figure out the corresponding bundle
    * based on implementation details.
    *
+   * @param reflection the reflection utility
    * @param obj the object for which to find the corresponding bundle.
    * @return the name/location of the corresponding bundle, {@link #NULL_BUNDLE} if the
    *     corresponding bundle could not be found in previous attempts (could be because it is
@@ -97,7 +112,7 @@ public class BundleUtil {
   @SuppressWarnings({
     "squid:S3776", /* Recursive logic and simple enough to not warrant decomposing more */
   })
-  private String get0(@Nullable Object obj) {
+  private String get0(ReflectionUtil reflection, @Nullable Object obj) {
     // NOTE: The logic here should be kept in sync with the logic in
     // org.codice.acdebugger.backdoor.Backdoor
     if (obj == null) {
@@ -112,123 +127,114 @@ public class BundleUtil {
       return bundle;
     } else if (obj instanceof StackFrame) {
       // cannot cache stack frames as calling a single method invalidates it including its hashCode
-      return get0(((StackFrame) obj).location().declaringType().classLoader());
+      return get0(reflection, ((StackFrame) obj).location().declaringType().classLoader());
     } else if (!(obj instanceof ObjectReference)) {
       return null;
     }
     bundle = getFromBackdoor(obj, cache); // first try via the backdoor
     if (bundle != null) {
-      return bundle;
+      return (bundle != BundleUtil.NULL_BUNDLE) ? bundle : null;
     }
     final ObjectReference ref = (ObjectReference) obj;
     final ReferenceType type = ref.referenceType();
 
-    if (debug.reflection().isAssignableFrom("Lorg/osgi/framework/Bundle;", type)) {
+    if (reflection.isAssignableFrom("Lorg/osgi/framework/Bundle;", type)) {
       bundle =
-          debug
-              .reflection()
-              .invoke(
-                  ref, "getSymbolicName", ReflectionUtil.METHOD_SIGNATURE_NO_ARGS_STRING_RESULT);
-    } else if (debug
-        .reflection()
-        .isAssignableFrom("Lorg/eclipse/osgi/internal/loader/EquinoxClassLoader;", type)) {
+          reflection.invoke(
+              ref, "getSymbolicName", ReflectionUtil.METHOD_SIGNATURE_NO_ARGS_STRING_RESULT);
+    } else if (reflection.isAssignableFrom(
+        "Lorg/eclipse/osgi/internal/loader/EquinoxClassLoader;", type)) {
       bundle =
           get0(
-              debug
-                  .reflection()
-                  .invoke(
-                      debug
-                          .reflection()
-                          .invoke(
-                              ref,
-                              "getBundleLoader",
-                              "()Lorg/eclipse/osgi/internal/loader/BundleLoader;"),
-                      "getWiring",
-                      "()Lorg/eclipse/osgi/container/ModuleWiring;"));
-    } else if (debug.reflection().isAssignableFrom("Ljava/security/ProtectionDomain;", type)) {
+              reflection,
+              reflection.invoke(
+                  reflection.invoke(
+                      ref, "getBundleLoader", "()Lorg/eclipse/osgi/internal/loader/BundleLoader;"),
+                  "getWiring",
+                  "()Lorg/eclipse/osgi/container/ModuleWiring;"));
+    } else if (reflection.isAssignableFrom("Ljava/security/ProtectionDomain;", type)) {
       // check if we have a protection domain with Eclipse's permissions
       final ObjectReference permissions =
-          invokeAndReturnNullIfNotFound(
+          reflection.invokeAndReturnNullIfNotFound(
               ref, "getPermissions", "()Ljava/security/PermissionCollection;");
 
-      if (debug
-          .reflection()
-          .isInstance("Lorg/eclipse/osgi/internal/permadmin/BundlePermissions;", permissions)) {
-        bundle = get0(permissions);
+      if (reflection.isInstance(
+          "Lorg/eclipse/osgi/internal/permadmin/BundlePermissions;", permissions)) {
+        bundle = get0(reflection, permissions);
       }
     } // no else here
     if (bundle == null) { // check if we have a getBundle() method
       // useful for org.eclipse.osgi.internal.loader.ModuleClassLoader$GenerationProtectionDomain,
-      // org.eclipse.osgi.container.ModuleWiring
-      // which exposes the bundle via a method
+      // org.eclipse.osgi.container.ModuleWiring which exposes the bundle via a method
       bundle =
-          get0(invokeAndReturnNullIfNotFound(ref, "getBundle", "()Lorg/osgi/framework/Bundle;"));
+          get0(
+              reflection,
+              reflection.invokeAndReturnNullIfNotFound(
+                  ref, "getBundle", "()Lorg/osgi/framework/Bundle;"));
     }
     if (bundle == null) { // check if we have a getBundleContext() method
       bundle =
           get0(
-              invokeAndReturnNullIfNotFound(
+              reflection,
+              reflection.invokeAndReturnNullIfNotFound(
                   ref, "getBundleContext", "()Lorg/osgi/framework/BundleContext;"));
     }
     if (bundle == null) { // check if we have a bundle field
       // useful for org.apache.felix.cm.impl.helper.BaseTracker$CMProtectionDomain,
       // which does not expose the bundle in any other ways
-      bundle = get0(debug.reflection().get(ref, "bundle", "Lorg/osgi/framework/Bundle;"));
+      bundle = get0(reflection, reflection.get(ref, "bundle", "Lorg/osgi/framework/Bundle;"));
     }
     if (bundle == null) { // check if we have a bundle context field
       // useful for org.apache.aries.blueprint.container.BlueprintProtectionDomain
       // which does not expose the bundle in any other ways
       bundle =
-          get0(debug.reflection().get(ref, "bundleContext", "Lorg/osgi/framework/BundleContext;"));
+          get0(
+              reflection,
+              reflection.get(ref, "bundleContext", "Lorg/osgi/framework/BundleContext;"));
     }
     if (bundle == null) { // check if we have a context field
       // useful for org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener
-      bundle = get0(debug.reflection().get(ref, "context", "Lorg/osgi/framework/BundleContext;"));
+      bundle =
+          get0(reflection, reflection.get(ref, "context", "Lorg/osgi/framework/BundleContext;"));
     }
     if (bundle == null) { // check if it has a delegate protection domain via a delegate field
       // useful for org.apache.karaf.util.jaas.JaasHelper$DelegatingProtectionDomain
-      bundle = get0(debug.reflection().get(ref, "delegate", "Ljava/security/ProtectionDomain;"));
+      bundle =
+          get0(reflection, reflection.get(ref, "delegate", "Ljava/security/ProtectionDomain;"));
     }
     if (bundle == null) {
       // for org.apache.aries.blueprint.container.AbstractServiceReferenceRecipe
       // we look for getBundleContextForServiceLookup()
       bundle =
           get0(
-              invokeAndReturnNullIfNotFound(
+              reflection,
+              reflection.invokeAndReturnNullIfNotFound(
                   ref, "getBundleContextForServiceLookup", "()Lorg/osgi/framework/BundleContext;"));
     }
     if (bundle == null) {
       // for org.apache.aries.blueprint.container.AbstractServiceReferenceRecipe$2$1
       // or org.apache.aries.blueprint.container.AbstractServiceReferenceRecipe$2
       // we shall look at the container class and figure it out from there
-      bundle = get0(debug.reflection().getContainerThis(ref));
+      bundle = get0(reflection, reflection.getContainerThis(ref));
     }
     if (bundle == null) { // check if it has a classloader via a getClassLoader() method
       // useful if it is a straight java.security.ProtectionDomain
       bundle =
-          get0(invokeAndReturnNullIfNotFound(ref, "getClassLoader", "()Ljava/lang/ClassLoader;"));
+          get0(
+              reflection,
+              reflection.invokeAndReturnNullIfNotFound(
+                  ref, "getClassLoader", "()Ljava/lang/ClassLoader;"));
     }
     if (bundle == null) {
       // for classloaders, check their parent classloader via a getParent() method
       // useful for org.apache.aries.proxy.impl.interfaces.ProxyClassLoader
-      bundle = get0(invokeAndReturnNullIfNotFound(ref, "getParent", "()Ljava/lang/ClassLoader;"));
+      bundle =
+          get0(
+              reflection,
+              reflection.invokeAndReturnNullIfNotFound(
+                  ref, "getParent", "()Ljava/lang/ClassLoader;"));
     }
     cache.put(obj, (bundle != null) ? bundle : BundleUtil.NULL_BUNDLE);
     return bundle;
-  }
-
-  @Nullable
-  private <T> T invokeAndReturnNullIfNotFound(
-      @Nullable ObjectReference obj, String name, String signature, Object... args) {
-    if (obj == null) {
-      return null;
-    }
-    final ReferenceType type =
-        (obj instanceof ClassObjectReference)
-            ? ((ClassObjectReference) obj).reflectedType()
-            : obj.referenceType();
-    final Method method = debug.reflection().findMethod(type, name, signature);
-
-    return (method != null) ? debug.reflection().invoke(obj, method, args) : null;
   }
 }

--- a/debugger/src/main/java/org/codice/acdebugger/api/BundleUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/BundleUtil.java
@@ -13,16 +13,17 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ReferenceType;
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.Value;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 /** Provides bundle utility functionality. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class BundleUtil implements LocationUtil {
   /** Internal key where bundle names for specific objects are cached. */
   private static final String BUNDLE_INFO_CACHE = "debug.bundle.info.cache";

--- a/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
@@ -73,7 +73,7 @@ public abstract class Debug {
    * @return the virtual machine to which this debugger is attached
    */
   public VirtualMachine virtualMachine() {
-    return reflection.getVirtualMachine();
+    return reflection.virtualMachine();
   }
 
   /**
@@ -83,7 +83,7 @@ public abstract class Debug {
    * @throws IllegalStateException if currently not associated with a thread
    */
   public ThreadReference thread() {
-    return reflection.getThread();
+    return reflection.thread();
   }
 
   /**
@@ -92,7 +92,7 @@ public abstract class Debug {
    * @return the backdoor utility
    */
   public Backdoor backdoor() {
-    return context.getBackdoor();
+    return context.backdoor();
   }
 
   /**
@@ -154,7 +154,7 @@ public abstract class Debug {
    *
    * @return the event request manager associated with the debugging session
    */
-  public EventRequestManager getEventRequestManager() {
+  public EventRequestManager eventRequestManager() {
     return virtualMachine().eventRequestManager();
   }
 
@@ -164,7 +164,7 @@ public abstract class Debug {
    * @return the current event associated with this debug instance
    * @throws IllegalStateException if currently not associated with an event
    */
-  public Event getEvent() {
+  public Event event() {
     if (event == null) {
       throw new IllegalStateException("missing event");
     }
@@ -302,7 +302,7 @@ public abstract class Debug {
     context.record(failure);
   }
 
-  DebugContext getContext() {
+  DebugContext context() {
     return context;
   }
 }

--- a/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
@@ -13,11 +13,13 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.VirtualMachine;
-import com.sun.jdi.event.Event;
-import com.sun.jdi.event.LocatableEvent;
-import com.sun.jdi.request.EventRequestManager;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.VirtualMachine; // NOSONAR
+import com.sun.jdi.event.Event; // NOSONAR
+import com.sun.jdi.event.LocatableEvent; // NOSONAR
+import com.sun.jdi.request.EventRequestManager; // NOSONAR
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.codice.acdebugger.impl.Backdoor;
@@ -25,7 +27,6 @@ import org.codice.acdebugger.impl.DebugContext;
 import org.codice.acdebugger.impl.SystemProperties;
 
 /** This class keeps information about the current debugging session/callback. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public abstract class Debug {
   /** The debug context for the current debug session. */
   private final DebugContext context;

--- a/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/Debug.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.codice.acdebugger.impl.Backdoor;
 import org.codice.acdebugger.impl.DebugContext;
+import org.codice.acdebugger.impl.SystemProperties;
 
 /** This class keeps information about the current debugging session/callback. */
 @SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
@@ -94,6 +95,15 @@ public abstract class Debug {
   }
 
   /**
+   * Accesses system properties util functionnality.
+   *
+   * @return a system properties utility for the attached VM
+   */
+  public SystemProperties properties() {
+    return context.properties();
+  }
+
+  /**
    * Accesses reflection-like functionality.
    *
    * @return a reflection instance onto which reflection-type methods can be invoked
@@ -112,12 +122,30 @@ public abstract class Debug {
   }
 
   /**
+   * Accesses location-specific functionality (i.e. {@link BundleUtil} or {@link DomainUtil}).
+   *
+   * @return a location utility instance onto which location-specific methods can be invoked
+   */
+  public LocationUtil locations() {
+    return isOSGi() ? bundles() : domains();
+  }
+
+  /**
    * Accesses bundle-specific functionality.
    *
    * @return a bundle utility instance onto which bundle-specific methods can be invoked
    */
   public BundleUtil bundles() {
     return new BundleUtil(this);
+  }
+
+  /**
+   * Accesses domain-specific functionality.
+   *
+   * @return a domain utility instance onto which domain-specific methods can be invoked
+   */
+  public DomainUtil domains() {
+    return new DomainUtil(this);
   }
 
   /**
@@ -179,6 +207,15 @@ public abstract class Debug {
    */
   public <T> void put(String key, T obj) {
     context.put(key, obj);
+  }
+
+  /**
+   * Checks if we are debugging an OSGi system.
+   *
+   * @return <code>true</code> if we are debugging an OSGi system; <code>false</code> if not
+   */
+  public boolean isOSGi() {
+    return context.isOSGi();
   }
 
   /**

--- a/debugger/src/main/java/org/codice/acdebugger/api/DomainUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/DomainUtil.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.api;
+
+import com.sun.jdi.ArrayReference;
+import com.sun.jdi.ClassObjectReference;
+import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.StackFrame;
+import com.sun.jdi.Value;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.codice.acdebugger.common.DomainInfo;
+
+/** Provides domain utility functionality. */
+@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
+public class DomainUtil implements LocationUtil {
+  /** Internal key where locations for specific domains are cached. */
+  private static final String DOMAIN_LOCATION_CACHE = "debug.domains.location.cache";
+
+  /** Constant used in the domain cache when a given object is associated with a null domain. */
+  private static final String NULL_DOMAIN = "NULL-DOMAIN";
+
+  private final Debug debug;
+
+  /**
+   * Creates a new domain utility instance.
+   *
+   * @param debug the current debug session
+   */
+  DomainUtil(Debug debug) {
+    this.debug = debug;
+  }
+
+  @Override
+  @Nullable
+  public String get(@Nullable Value domain) {
+    if (!(domain instanceof ObjectReference)) {
+      return null;
+    }
+    return get((ObjectReference) domain);
+  }
+
+  @Override
+  @Nullable
+  public String get(StackFrame frame) {
+    final ObjectReference thisObject = frame.thisObject();
+
+    return (thisObject != null) ? get(thisObject.referenceType()) : null;
+  }
+
+  /**
+   * Gets domain information for the given domain.
+   *
+   * @param domain the domain to find the corresponding location
+   * @return the corresponding location or <code>null</code> if none exist
+   */
+  @Nullable
+  public String get(@Nullable ObjectReference domain) {
+    if (domain == null) {
+      return null;
+    }
+    final Map<Object, String> cache =
+        debug.computeIfAbsent(DomainUtil.DOMAIN_LOCATION_CACHE, ConcurrentHashMap::new);
+    String location = cache.get(domain);
+
+    if (location == null) {
+      location = getFromBackdoor(domain, cache);
+    }
+    if (location != null) {
+      return (location != DomainUtil.NULL_DOMAIN) ? location : null;
+    }
+    final ReflectionUtil reflection = debug.reflection();
+
+    location =
+        reflection.toString(
+            reflection.invokeAndReturnNullIfNotFound(
+                reflection.invoke(
+                    (ObjectReference) domain, "getCodeSource", "()Ljava/security/CodeSource;"),
+                "getLocation",
+                "()Ljava/net/URL;"));
+    if (location != null) {
+      if (location.regionMatches(true, 0, "file:/", 0, 6)) {
+        location = debug.properties().compress(debug, location);
+      }
+      cache.put(domain, location);
+    } else {
+      cache.put(domain, DomainUtil.NULL_DOMAIN);
+    }
+    return location;
+  }
+
+  /**
+   * Gets domain information for the given class.
+   *
+   * @param clazz the class to find the corresponding domain location
+   * @return the corresponding domain location or <code>null</code> if none exist
+   */
+  @Nullable
+  public String get(@Nullable ReferenceType clazz) {
+    if (clazz == null) {
+      return null;
+    }
+    return get(clazz.classObject());
+  }
+
+  /**
+   * Gets domain information for the given class.
+   *
+   * @param clazz the class to find the corresponding domain location
+   * @return the corresponding domain location or <code>null</code> if none exist
+   */
+  @Nullable
+  public String get(@Nullable ClassObjectReference clazz) {
+    if (clazz == null) {
+      return null;
+    }
+    final Map<Object, String> cache =
+        debug.computeIfAbsent(DomainUtil.DOMAIN_LOCATION_CACHE, ConcurrentHashMap::new);
+    String location = cache.get(clazz);
+
+    if (location != null) {
+      return (location != DomainUtil.NULL_DOMAIN) ? location : null;
+    }
+    // getProtectionDomain0() is private in class Class and avoids the security manager check which
+    // would create a recursion which we don't want to handle here. In addition, it returns a fake
+    // domain if none is associated with the class
+    location =
+        get(
+            (ObjectReference)
+                debug
+                    .reflection()
+                    .invoke(clazz, "getProtectionDomain0", "()Ljava/security/ProtectionDomain;"));
+    cache.put(clazz, (location != null) ? location : DomainUtil.NULL_DOMAIN);
+    return location;
+  }
+
+  /**
+   * Gets domain information for the given domains and permission.
+   *
+   * @param domainsRef the reference to the array of domains to find the corresponding information
+   * @param domains the list of domains to find the corresponding information
+   * @param permission the permission for which to verify if the domains are granted it
+   * @param permissionInfos the corresponding permissions info
+   * @param firstDomainWithoutPermission the index for the first domain in the array which is known
+   *     to not have permissions; after that it is unknown wether a domain has or doesn't have the
+   *     permission
+   * @return a corresponding list of domain information
+   */
+  public List<DomainInfo> get(
+      ArrayReference domainsRef,
+      List<Value> domains,
+      ObjectReference permission,
+      Set<String> permissionInfos,
+      int firstDomainWithoutPermission) {
+    final Map<Object, String> cache =
+        debug.computeIfAbsent(DomainUtil.DOMAIN_LOCATION_CACHE, ConcurrentHashMap::new);
+    List<DomainInfo> info = getFromBackdoor(domainsRef, domains, permission, cache);
+
+    if (info != null) {
+      return info;
+    }
+    info = new ArrayList<>(domains.size());
+    for (int i = 0; i < domains.size(); i++) {
+      final ObjectReference domain = (ObjectReference) domains.get(i);
+      final String location = get(domain);
+      boolean implies;
+
+      if (i < firstDomainWithoutPermission) {
+        implies = true;
+      } else {
+        implies = debug.permissions().implies(location, permissionInfos); // check cache
+        if (!implies && (i > firstDomainWithoutPermission)) { // check attached VM
+          // we now the first one doesn't so no need to check again
+          implies = debug.permissions().implies(domain, permission);
+        }
+      }
+      info.add(new DomainInfo(location, implies));
+    }
+    return info;
+  }
+
+  @Nullable
+  @SuppressWarnings({
+    "squid:S1181", /* letting VirtualMachineErrors bubble out directly, so ok to catch Throwable */
+    "squid:S1148" /* this is a console application */
+  })
+  private List<DomainInfo> getFromBackdoor(
+      ArrayReference domainsRef,
+      List<Value> domains,
+      ObjectReference permission,
+      Map<Object, String> cache) {
+    try {
+      final List<DomainInfo> info = debug.backdoor().getDomainInfo(debug, domainsRef, permission);
+
+      for (int i = 0; i < info.size(); i++) {
+        final String location = info.get(i).getLocationString();
+
+        cache.put(domains.get(i), (location != null) ? location : DomainUtil.NULL_DOMAIN);
+      }
+      return info;
+    } catch (VirtualMachineError e) {
+      throw e;
+    } catch (IllegalStateException e) { // ignore and continue the long way
+    } catch (Throwable t) {
+      // ignore and continue the long way which might require more calls to the process
+      t.printStackTrace();
+    }
+    return null;
+  }
+
+  @Nullable
+  @SuppressWarnings({
+    "squid:S1181", /* letting VirtualMachineErrors bubble out directly, so ok to catch Throwable */
+    "squid:S1148" /* this is a console application */
+  })
+  private String getFromBackdoor(ObjectReference domain, Map<Object, String> cache) {
+    try {
+      String location = debug.backdoor().getDomain(debug, domain);
+
+      if (location == null) {
+        location = DomainUtil.NULL_DOMAIN;
+      }
+      cache.put(domain, location);
+      return location;
+    } catch (VirtualMachineError e) {
+      throw e;
+    } catch (IllegalStateException e) { // ignore and continue the long way
+    } catch (Throwable t) {
+      // ignore and continue the long way which might require more calls to the process
+      t.printStackTrace();
+    }
+    return null;
+  }
+}

--- a/debugger/src/main/java/org/codice/acdebugger/api/DomainUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/DomainUtil.java
@@ -13,12 +13,14 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ArrayReference;
-import com.sun.jdi.ClassObjectReference;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ReferenceType;
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.Value;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ArrayReference; // NOSONAR
+import com.sun.jdi.ClassObjectReference; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +30,6 @@ import javax.annotation.Nullable;
 import org.codice.acdebugger.common.DomainInfo;
 
 /** Provides domain utility functionality. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class DomainUtil implements LocationUtil {
   /** Internal key where locations for specific domains are cached. */
   private static final String DOMAIN_LOCATION_CACHE = "debug.domains.location.cache";

--- a/debugger/src/main/java/org/codice/acdebugger/api/LocationUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/LocationUtil.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.api;
+
+import com.sun.jdi.StackFrame;
+import com.sun.jdi.Value;
+import javax.annotation.Nullable;
+
+/** Provides location utility functionality. */
+@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
+public interface LocationUtil {
+  /**
+   * Gets the location (i.e. bundle name or domain location) for the given domain.
+   *
+   * @param domain the domain to find the corresponding location
+   * @return the corresponding location or <code>null</code> if none exist
+   */
+  @Nullable
+  public String get(@Nullable Value domain);
+
+  /**
+   * Gets the location (i.e. bundle name or domain location) for the given stack frame.
+   *
+   * @param frame the stack frame to find the corresponding domain location
+   * @return the corresponding location or <code>null</code> if none exist
+   */
+  @Nullable
+  public String get(StackFrame frame);
+}

--- a/debugger/src/main/java/org/codice/acdebugger/api/LocationUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/LocationUtil.java
@@ -13,12 +13,13 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.Value;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
 import javax.annotation.Nullable;
 
 /** Provides location utility functionality. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public interface LocationUtil {
   /**
    * Gets the location (i.e. bundle name or domain location) for the given domain.

--- a/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
@@ -13,8 +13,10 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ClassType;
-import com.sun.jdi.ObjectReference;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ClassType; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -26,7 +28,6 @@ import javax.annotation.Nullable;
 import org.codice.acdebugger.common.ServicePermissionInfo;
 
 /** Provides permission-specific functionality. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class PermissionUtil {
   /** Internal key where information about service properties is cached. */
   private static final String SERVICE_PROPERTY_CACHE = "debug.service.property.cache";

--- a/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
@@ -48,34 +48,34 @@ public class PermissionUtil {
   }
 
   /**
-   * Checks if a bundle is or was temporarily granted a given permission (as long as the information
+   * Checks if a domain is or was temporarily granted a given permission (as long as the information
    * was previously cached using {@link #grant(String, String)}) or {@link #grant(String, Set)}.
    *
    * <p><i>Note:</i> This method only looks at the local cache.
    *
-   * @param bundle the bundle to check for
+   * @param domain the bundle name or domain location to check for
    * @param permission the permission string to check for
-   * @return <code>true</code> if the bundle is or was granted the specified permission; <code>
+   * @return <code>true</code> if the domain is or was granted the specified permission; <code>
    *     false</code> if not
    */
-  public boolean implies(String bundle, String permission) {
-    return debug.getContext().hasPermission(bundle, permission);
+  public boolean implies(String domain, String permission) {
+    return debug.getContext().hasPermission(domain, permission);
   }
 
   /**
-   * Checks if a bundle is or was temporarily granted the given permissions (as long as the
+   * Checks if a domain is or was temporarily granted the given permissions (as long as the
    * information was previously cached using {@link #grant(String, String)}) or {@link
    * #grant(String, Set)}.
    *
    * <p><i>Note:</i> This method only looks at the local cache.
    *
-   * @param bundle the bundle to check for
+   * @param domain the bundle name or domain location to check for
    * @param permissions the permission strings to check for
-   * @return <code>true</code> if the bundle is or was granted the specified permissions; <code>
+   * @return <code>true</code> if the domain is or was granted the specified permissions; <code>
    *     false</code> if not
    */
-  public boolean implies(String bundle, Set<String> permissions) {
-    return debug.getContext().hasPermissions(bundle, permissions);
+  public boolean implies(String domain, Set<String> permissions) {
+    return debug.getContext().hasPermissions(domain, permissions);
   }
 
   /**
@@ -133,47 +133,47 @@ public class PermissionUtil {
   }
 
   /**
-   * Temporarily grants a bundle a set of permissions if not already granted.
+   * Temporarily grants a domain a set of permissions if not already granted.
    *
    * <p><i>Note:</i> This method will automatically grant the permissions in the attached VM if the
    * debugger is running in continuous mode and granting was enabled and if attached to VM running
-   * the backdoor bundle.
+   * the backdoor.
    *
-   * @param bundle the bundle to grant the permissions to
+   * @param domain the bundle name or domain location to grant the permissions to
    * @param permissions the permissions to be granted
-   * @return <code>true</code> if the permissions were granted to the specified bundle; <code>false
+   * @return <code>true</code> if the permissions were granted to the specified domain; <code>false
    *     </code> if at least one was already granted
    */
-  public boolean grant(String bundle, Set<String> permissions) {
-    if (bundle == null) {
+  public boolean grant(String domain, Set<String> permissions) {
+    if (domain == null) {
       return false;
     }
-    return permissions.stream().map(p -> grant(bundle, p)).reduce(true, Boolean::logicalAnd);
+    return permissions.stream().map(p -> grant(domain, p)).reduce(true, Boolean::logicalAnd);
   }
 
   /**
-   * Temporarily grants a bundle a given permission if not already granted.
+   * Temporarily grants a domain a given permission if not already granted.
    *
    * <p><i>Note:</i> This method will automatically grant the permission in the attached VM if the
    * debugger is running in continuous mode and granting was enabled and if attached to VM running
-   * the backdoor bundle.
+   * the backdoor.
    *
-   * @param bundle the bundle to grant the permission to
+   * @param domain the bundle name or domain location to grant the permission to
    * @param permission the permission to be granted
-   * @return <code>true</code> if the permission was granted to the specified bundle; <code>false
+   * @return <code>true</code> if the permission was granted to the specified domain; <code>false
    *     </code> if it was already granted
    */
   @SuppressWarnings({
     "squid:S1181", /* letting VirtualMachineErrors bubble out directly, so ok to catch Throwable */
     "squid:S1148" /* this is a console application */
   })
-  public boolean grant(String bundle, String permission) {
-    final boolean granted = debug.getContext().grantPermission(bundle, permission);
+  public boolean grant(String domain, String permission) {
+    final boolean granted = debug.getContext().grantPermission(domain, permission);
 
     if (granted && debug.isGranting() && debug.isContinuous()) {
       // try to grant the permission in the VM via the backdoor
       try {
-        debug.backdoor().grantPermission(debug, bundle, permission);
+        debug.backdoor().grantPermission(debug, domain, permission);
       } catch (VirtualMachineError e) {
         throw e;
       } catch (IllegalStateException e) { // ignore and continue
@@ -230,15 +230,16 @@ public class PermissionUtil {
             .reflection()
             .invoke(
                 permission, "getActions", ReflectionUtil.METHOD_SIGNATURE_NO_ARGS_STRING_RESULT);
+    final ReflectionUtil reflection = debug.reflection();
+    final boolean isFilePermission;
 
-    if (debug.reflection().isInstance("Lorg/osgi/framework/ServicePermission;", permission)) {
+    if (reflection.isInstance("Lorg/osgi/framework/ServicePermission;", permission)) {
       // for ServicePermission, we typically get something like "(service.id=14)"
       // for the permission name which is not useful; so we first try to get the set
       // of object classes representing the services and if we get a set then we can
       // create permissions for each names. If we get null then we typically can rely
       // on the permission name
-      final String[] objectClass =
-          debug.reflection().get(permission, "objectClass", "[Ljava/lang/String;");
+      final String[] objectClass = reflection.get(permission, "objectClass", "[Ljava/lang/String;");
 
       if (objectClass != null) {
         return Stream.of(objectClass)
@@ -248,15 +249,19 @@ public class PermissionUtil {
                         obj.name(), n, actions))
             .collect(Collectors.toSet());
       }
+      isFilePermission = false;
+    } else {
+      isFilePermission = reflection.isInstance("Ljava/io/FilePermission;", permission);
+    }
+    String name =
+        reflection.invoke(
+            permission, "getName", ReflectionUtil.METHOD_SIGNATURE_NO_ARGS_STRING_RESULT);
+
+    if (isFilePermission) {
+      name = debug.properties().compress(debug, name);
     }
     return Collections.singleton(
-        org.codice.acdebugger.common.PermissionUtil.getPermissionString(
-            obj.name(),
-            debug
-                .reflection()
-                .invoke(
-                    permission, "getName", ReflectionUtil.METHOD_SIGNATURE_NO_ARGS_STRING_RESULT),
-            actions));
+        org.codice.acdebugger.common.PermissionUtil.getPermissionString(obj.name(), name, actions));
   }
 
   /**

--- a/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/PermissionUtil.java
@@ -60,7 +60,7 @@ public class PermissionUtil {
    *     false</code> if not
    */
   public boolean implies(String domain, String permission) {
-    return debug.getContext().hasPermission(domain, permission);
+    return debug.context().hasPermission(domain, permission);
   }
 
   /**
@@ -76,7 +76,7 @@ public class PermissionUtil {
    *     false</code> if not
    */
   public boolean implies(String domain, Set<String> permissions) {
-    return debug.getContext().hasPermissions(domain, permissions);
+    return debug.context().hasPermissions(domain, permissions);
   }
 
   /**
@@ -169,7 +169,7 @@ public class PermissionUtil {
     "squid:S1148" /* this is a console application */
   })
   public boolean grant(String domain, String permission) {
-    final boolean granted = debug.getContext().grantPermission(domain, permission);
+    final boolean granted = debug.context().grantPermission(domain, permission);
 
     if (granted && debug.isGranting() && debug.isContinuous()) {
       // try to grant the permission in the VM via the backdoor
@@ -291,14 +291,14 @@ public class PermissionUtil {
 
       if (debug.isContinuous()) {
         // first make sure we cache all permissions since we granted them if they were missing
-        permissionStrings.forEach(p -> debug.getContext().grantPermission(bundle, p));
+        permissionStrings.forEach(p -> debug.context().grantPermission(bundle, p));
       }
       // next cache all info we have about pre-existed implied permissions
       // and remove them from the complete list of permissions since they were not missing
       info.getImpliedPermissionStrings()
           .stream()
           .peek(permissionStrings::remove)
-          .forEach(p -> debug.getContext().grantPermission(bundle, p));
+          .forEach(p -> debug.context().grantPermission(bundle, p));
       if (!info.implies()) { // we didn't have all permissions
         return permissionStrings;
       }

--- a/debugger/src/main/java/org/codice/acdebugger/api/ReflectionUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/ReflectionUtil.java
@@ -87,7 +87,7 @@ public class ReflectionUtil {
    *
    * @return the virtual machine to which this debugger is attached
    */
-  public VirtualMachine getVirtualMachine() {
+  public VirtualMachine virtualMachine() {
     return vm;
   }
 
@@ -97,7 +97,7 @@ public class ReflectionUtil {
    * @return the current thread associated with this debug instance
    * @throws IllegalStateException if currently not associated with a thread
    */
-  public ThreadReference getThread() {
+  public ThreadReference thread() {
     if (thread == null) {
       throw new IllegalStateException("missing thread reference");
     }
@@ -471,8 +471,7 @@ public class ReflectionUtil {
       }
       return (T)
           fromMirror(
-              obj.invokeMethod(
-                  getThread(), method, values, ObjectReference.INVOKE_SINGLE_THREADED));
+              obj.invokeMethod(thread(), method, values, ObjectReference.INVOKE_SINGLE_THREADED));
     } catch (Exception e) {
       throw new Error(e);
     } finally {
@@ -558,8 +557,7 @@ public class ReflectionUtil {
       }
       return (T)
           fromMirror(
-              clazz.invokeMethod(
-                  getThread(), method, values, ObjectReference.INVOKE_SINGLE_THREADED));
+              clazz.invokeMethod(thread(), method, values, ObjectReference.INVOKE_SINGLE_THREADED));
     } catch (Exception e) {
       throw new Error(e);
     } finally {
@@ -608,7 +606,7 @@ public class ReflectionUtil {
           protect(
               () ->
                   type.newInstance(
-                      getThread(),
+                      thread(),
                       ctor,
                       values,
                       ObjectReference.INVOKE_SINGLE_THREADED

--- a/debugger/src/main/java/org/codice/acdebugger/api/ReflectionUtil.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/ReflectionUtil.java
@@ -13,28 +13,30 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.ArrayReference;
-import com.sun.jdi.BooleanValue;
-import com.sun.jdi.ByteValue;
-import com.sun.jdi.CharValue;
-import com.sun.jdi.ClassObjectReference;
-import com.sun.jdi.ClassType;
-import com.sun.jdi.DoubleValue;
-import com.sun.jdi.Field;
-import com.sun.jdi.FloatValue;
-import com.sun.jdi.IntegerValue;
-import com.sun.jdi.LongValue;
-import com.sun.jdi.Method;
-import com.sun.jdi.ObjectCollectedException;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ReferenceType;
-import com.sun.jdi.ShortValue;
-import com.sun.jdi.StringReference;
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.Type;
-import com.sun.jdi.Value;
-import com.sun.jdi.VirtualMachine;
-import com.sun.jdi.VoidValue;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ArrayReference; // NOSONAR
+import com.sun.jdi.BooleanValue; // NOSONAR
+import com.sun.jdi.ByteValue; // NOSONAR
+import com.sun.jdi.CharValue; // NOSONAR
+import com.sun.jdi.ClassObjectReference; // NOSONAR
+import com.sun.jdi.ClassType; // NOSONAR
+import com.sun.jdi.DoubleValue; // NOSONAR
+import com.sun.jdi.Field; // NOSONAR
+import com.sun.jdi.FloatValue; // NOSONAR
+import com.sun.jdi.IntegerValue; // NOSONAR
+import com.sun.jdi.LongValue; // NOSONAR
+import com.sun.jdi.Method; // NOSONAR
+import com.sun.jdi.ObjectCollectedException; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
+import com.sun.jdi.ShortValue; // NOSONAR
+import com.sun.jdi.StringReference; // NOSONAR
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.Type; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
+import com.sun.jdi.VirtualMachine; // NOSONAR
+import com.sun.jdi.VoidValue; // NOSONAR
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -47,7 +49,6 @@ import javax.annotation.Nullable;
 import org.codice.acdebugger.impl.DebugContext;
 
 /** Provides reflection-style functionality via the debugger's interface. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class ReflectionUtil {
   static final String METHOD_SIGNATURE_NO_ARGS_STRING_RESULT = "()Ljava/lang/String;";
 
@@ -420,7 +421,7 @@ public class ReflectionUtil {
 
     if (method == null) {
       throw new Error(
-          "could not find method '" + name + "[" + signature + "]' for: " + type.name());
+          String.format("could not find method '%s[%s]' for: %s", name, signature, type.name()));
     }
     return invoke(obj, method, args);
   }
@@ -506,7 +507,8 @@ public class ReflectionUtil {
 
     if (method == null) {
       throw new Error(
-          "could not find method '" + name + "[" + signature + "]' for: " + type.name());
+          String.format(
+              "could not find static method '%s[%s]' for: %s", name, signature, type.name()));
     }
     return invokeStatic(clazz, method, args);
   }
@@ -644,7 +646,8 @@ public class ReflectionUtil {
     final Method ctor = findConstructor(type, signature);
 
     if (ctor == null) {
-      throw new Error("could not find constructor '[" + signature + "]' for: " + type.name());
+      throw new Error(
+          String.format("could not find constructor '[%s]' for: %s", signature, type.name()));
     }
     return newInstance(type, ctor, args);
   }

--- a/debugger/src/main/java/org/codice/acdebugger/api/SecurityFailure.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/SecurityFailure.java
@@ -63,7 +63,8 @@ public interface SecurityFailure {
   /**
    * Dumps info about this security failure along with its solutions.
    *
+   * @param osgi <code>true</code> if attached to an OSGi container; <code>false</code> if not
    * @param prefix a prefix string to dump in fron of the first line
    */
-  public void dump(String prefix);
+  public void dump(boolean osgi, String prefix);
 }

--- a/debugger/src/main/java/org/codice/acdebugger/api/SecuritySolution.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/SecuritySolution.java
@@ -110,45 +110,9 @@ public class SecuritySolution implements Comparable<SecuritySolution> {
 
     if (!grantedDomains.isEmpty()) {
       if (osgi) {
-        System.out.println(
-            ACDebugger.PREFIX
-                + prefix
-                + "    Add the following permission block to the appropriate policy file:");
-        System.out.println(
-            ACDebugger.PREFIX
-                + prefix
-                + "        grant codeBase \"file:/"
-                + grantedDomains.stream().sorted().collect(Collectors.joining("/"))
-                + "\" {");
-        permissionInfos
-            .stream()
-            .sorted()
-            .forEach(
-                p ->
-                    System.out.println(
-                        ACDebugger.PREFIX + prefix + "            permission " + p + ";"));
-        System.out.println(ACDebugger.PREFIX + prefix + "        }");
+        printGrantedBundles(prefix);
       } else {
-        final String s = (grantedDomains.size() > 1) ? "s" : "";
-
-        System.out.println(
-            ACDebugger.PREFIX
-                + prefix
-                + "    Add the following permission block"
-                + s
-                + " to the appropriate policy file:");
-        for (final String location : grantedDomains) {
-          System.out.println(
-              ACDebugger.PREFIX + prefix + "        grant codeBase \"" + location + "\" {");
-          permissionInfos
-              .stream()
-              .sorted()
-              .forEach(
-                  p ->
-                      System.out.println(
-                          ACDebugger.PREFIX + prefix + "            permission " + p + ";"));
-          System.out.println(ACDebugger.PREFIX + prefix + "        }");
-        }
+        printGrantedDomains(prefix);
       }
       and = "and a";
     } else {
@@ -217,6 +181,52 @@ public class SecuritySolution implements Comparable<SecuritySolution> {
           && doPrivileged.equals(s.doPrivileged);
     }
     return false;
+  }
+
+  @SuppressWarnings("squid:S106" /* this is a console application */)
+  private void printGrantedDomains(String prefix) {
+    final String s = (grantedDomains.size() > 1) ? "s" : "";
+
+    System.out.println(
+        ACDebugger.PREFIX
+            + prefix
+            + "    Add the following permission block"
+            + s
+            + " to the appropriate policy file:");
+    for (final String location : grantedDomains) {
+      System.out.println(
+          ACDebugger.PREFIX + prefix + "        grant codeBase \"" + location + "\" {");
+      permissionInfos
+          .stream()
+          .sorted()
+          .forEach(
+              p ->
+                  System.out.println(
+                      ACDebugger.PREFIX + prefix + "            permission " + p + ";"));
+      System.out.println(ACDebugger.PREFIX + prefix + "        }");
+    }
+  }
+
+  @SuppressWarnings("squid:S106" /* this is a console application */)
+  private void printGrantedBundles(String prefix) {
+    System.out.println(
+        ACDebugger.PREFIX
+            + prefix
+            + "    Add the following permission block to the appropriate policy file:");
+    System.out.println(
+        ACDebugger.PREFIX
+            + prefix
+            + "        grant codeBase \"file:/"
+            + grantedDomains.stream().sorted().collect(Collectors.joining("/"))
+            + "\" {");
+    permissionInfos
+        .stream()
+        .sorted()
+        .forEach(
+            p ->
+                System.out.println(
+                    ACDebugger.PREFIX + prefix + "            permission " + p + ";"));
+    System.out.println(ACDebugger.PREFIX + prefix + "        }");
   }
 
   private int compareSizes(Collection<?> c1, Collection<?> c2) {

--- a/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
@@ -13,9 +13,11 @@
  */
 package org.codice.acdebugger.api;
 
-import com.sun.jdi.Location;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ReferenceType;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.Location; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -25,7 +27,6 @@ import javax.annotation.Nullable;
 import org.codice.acdebugger.common.Resources;
 
 /** Information about a particular frame in a calling stack. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class StackFrameInformation implements Comparable<StackFrameInformation> {
   /** Constant for how to represent bundle 0 to users. */
   public static final String BUNDLE0 = "bundle-0";
@@ -268,11 +269,13 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
    */
   public String toString(boolean osgi, @Nullable Set<String> privilegedDomains) {
     final String p = (isPrivileged(privilegedDomains) ? "" : "*");
-    final String d =
-        ((domain != null)
-            ? domain
-            : (osgi ? StackFrameInformation.BUNDLE0 : StackFrameInformation.BOOT_DOMAIN));
+    final String d;
 
+    if (domain != null) {
+      d = domain;
+    } else {
+      d = osgi ? StackFrameInformation.BUNDLE0 : StackFrameInformation.BOOT_DOMAIN;
+    }
     return p + d + "(" + location + ") <" + classOrInstanceAtLocation + '>';
   }
 
@@ -305,12 +308,11 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
   private boolean isProxyClass(Debug debug) {
     final ReflectionUtil reflection = debug.reflection();
 
-    if (thisObject != null) {
-      if (StackFrameInformation.PROXIES
-          .stream()
-          .anyMatch(p -> reflection.isInstance(p, thisObject))) {
-        return true;
-      }
+    if ((thisObject != null)
+        && StackFrameInformation.PROXIES
+            .stream()
+            .anyMatch(p -> reflection.isInstance(p, thisObject))) {
+      return true;
     }
     if (locationClass != null) {
       // although unlikely that a normal class would extend a proxy generated class, let's still

--- a/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
@@ -256,9 +256,13 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
   public int compareTo(StackFrameInformation f) {
     if (f == this) {
       return 0;
-    }
-    if (domain != f.domain) {
-      final int d = (domain == null) ? -1 : domain.compareTo(f.domain);
+    } else if (domain != f.domain) {
+      if (domain == null) {
+        return -1;
+      } else if (f.domain == null) {
+        return 1;
+      }
+      final int d = domain.compareTo(f.domain);
 
       if (d != 0) {
         return d;
@@ -293,7 +297,7 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
 
   @Override
   public String toString() {
-    return toString(false, null);
+    return toString(true, null);
   }
 
   private boolean isThirdPartyDomain(Debug debug) {

--- a/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
@@ -13,24 +13,25 @@
  */
 package org.codice.acdebugger.api;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.LineProcessor;
-import com.google.common.io.Resources;
 import com.sun.jdi.Location;
 import com.sun.jdi.ObjectReference;
-import java.io.IOError;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
+import com.sun.jdi.ReferenceType;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.codice.acdebugger.common.Resources;
 
 /** Information about a particular frame in a calling stack. */
 @SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class StackFrameInformation implements Comparable<StackFrameInformation> {
-  /** Constant for how to represent bundle-0 to users. */
+  /** Constant for how to represent bundle 0 to users. */
   public static final String BUNDLE0 = "bundle-0";
+
+  /** Constant for how to represent the boot domain location to users. */
+  public static final String BOOT_DOMAIN = "boot:";
 
   /**
    * Fake stack frame information for a <code>doPrivileged()</code> call to the access controller.
@@ -38,105 +39,121 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
   public static final StackFrameInformation DO_PRIVILEGED =
       new StackFrameInformation(
           null,
-          "java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)");
+          "java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)",
+          null,
+          "java.security.AccessController",
+          null);
 
   /**
-   * Sets of 3rd party prefixes for bundles and/or package names. These are used as indicator of
+   * Set of 3rd party prefixes for bundles and/or package names. These are used as indicator of
    * where we are shouldn't provide solutions that consists in extending privileges using <code>
    * doPrivileged()</code> blocks.
    */
-  private static final Set<String> THIRD_PARTY_PREFIXES;
+  private static final List<String> THIRD_PARTY_PREFIXES =
+      Resources.readLines(StackFrameInformation.class, "thirdparty-prefixes.txt");
 
   /**
-   * Sets of signatures for proxy classes. These are used as indicator of * where we are shouldn't
+   * Set of 3rd party patterns for domain locations. These are used as indicator of where we are
+   * shouldn't provide solutions that consists in extending privileges using <code>
+   * doPrivileged()</code> blocks.
+   */
+  private static final List<Pattern> THIRD_PARTY_PATTERNS =
+      Resources.readLines(StackFrameInformation.class, "thirdparty-patterns.txt", Pattern::compile);
+
+  /**
+   * Set of signatures for proxy classes. These are used as indicator of * where we are shouldn't
    * provide solutions that consists in extending privileges using <code>doPrivileged()</code>
    * blocks.
    */
-  private static final Set<String> PROXIES;
-
-  static {
-    try {
-      THIRD_PARTY_PREFIXES =
-          Resources.readLines(
-              Resources.getResource("thirdparty-prefixes.txt"), Charsets.UTF_8, new SetProcessor());
-      PROXIES =
-          Resources.readLines(
-              Resources.getResource("proxies.txt"), Charsets.UTF_8, new SetProcessor());
-    } catch (IOException e) {
-      throw new IOError(e);
-    }
-  }
+  private static final List<String> PROXIES =
+      Resources.readLines(StackFrameInformation.class, "proxies.txt");
 
   /**
-   * The bundle corresponding to this stack frame or <code>null</code> if it corresponds to <code>
-   * bundle-0</code>.
+   * The bundle name or domain location corresponding to this stack frame or <code>null</code> if it
+   * corresponds to <code>bundle-0</code> or the boot domain or if unknown.
    */
-  private final String bundle;
+  @Nullable private final String domain;
 
   /** String representation of the location in the code for this stack frame. */
   private final String location;
 
-  /** Reference to the <code>this</code> at that location. */
+  /** Class at above location. */
+  @Nullable private final ReferenceType locationClass;
+
+  /** Class name at above location. */
+  private final String locationClassName;
+
+  /**
+   * Reference to the <code>this</code> at that location or <code>null</code> if it is a static
+   * method call.
+   */
   @Nullable private final ObjectReference thisObject;
 
-  private StackFrameInformation(String bundle, String location, ObjectReference thisObject) {
-    this.bundle = bundle;
+  /** Class (if a static method call) or instance (if not) at the corresponding location. */
+  private final String classOrInstanceAtLocation;
+
+  private StackFrameInformation(
+      String domain,
+      String location,
+      @Nullable ReferenceType locationClass,
+      String locationClassName,
+      @Nullable ObjectReference thisObject,
+      String classOrInstanceAtLocation) {
+    this.domain = domain;
     this.location = location;
+    this.locationClass = locationClass;
+    this.locationClassName = locationClassName;
     this.thisObject = thisObject;
+    this.classOrInstanceAtLocation = classOrInstanceAtLocation;
+  }
+
+  private StackFrameInformation(
+      String domain,
+      String location,
+      @Nullable ReferenceType locationClass,
+      String locationClassName,
+      @Nullable ObjectReference thisObject) {
+    this(
+        domain,
+        location,
+        locationClass,
+        locationClassName,
+        thisObject,
+        (thisObject != null) ? thisObject.toString() : "class of " + locationClassName);
+  }
+
+  private StackFrameInformation(
+      String domain,
+      String location,
+      ReferenceType locationClass,
+      @Nullable ObjectReference thisObject) {
+    this(domain, location, locationClass, locationClass.name(), thisObject);
   }
 
   /**
    * Constructs a stack frame location.
    *
-   * <p><i>Note:</i> This flavor of the constructor provides no reference to the <code>this</code>
-   * object
-   *
-   * @param bundle the bundle corresponding to that location or <code>null</code> if it is <code>
-   *     bundle-0</code>
-   * @param location the string representation of the location
-   */
-  public StackFrameInformation(@Nullable String bundle, String location) {
-    this(bundle, location, null);
-  }
-
-  /**
-   * Constructs a stack frame location.
-   *
-   * <p><i>Note:</i> This flavor of the constructor provides no reference to the <code>this</code>
-   * object
-   *
-   * @param bundle the bundle corresponding to that location or <code>null</code> if it is <code>
-   *     bundle-0</code>
-   * @param location the location
-   */
-  public StackFrameInformation(@Nullable String bundle, Location location) {
-    this(bundle, location.toString(), null);
-  }
-
-  /**
-   * Constructs a stack frame location.
-   *
-   * @param bundle the bundle corresponding to that location or <code>null</code> if it is <code>
-   *     bundle-0</code>
+   * @param domain the bundle name or domain location corresponding to that location or <code>null
+   *     </code> if it is <code>bundle-0</code> or boot domain or if unknown
    * @param location the string representation of the location
    * @param thisObject the reference to the <code>this</code> object at that location or <code>null
    *     </code> if unknown
    */
   public StackFrameInformation(
-      @Nullable String bundle, Location location, @Nullable ObjectReference thisObject) {
-    this(bundle, location.toString(), thisObject);
+      @Nullable String domain, Location location, @Nullable ObjectReference thisObject) {
+    this(domain, location.toString(), location.declaringType(), thisObject);
   }
 
   /**
-   * Gets the name of the bundle corresponding to this stack frame or <code>null</code> if it
-   * corresponds to <code>bundle-0</code>.
+   * Gets the name of the bundle or the domain location corresponding to this stack frame or <code>
+   * null</code> if it corresponds to <code>bundle-0</code> or the boot domain or if unknown.
    *
-   * @return the name of the bundle at that location or <code>null</code> if it corresponds to
-   *     <code>bundle-0</code>
+   * @return the name of the bundle or domain location at that location or <code>null</code> if it
+   *     corresponds to <code>bundle-0</code> or the boot domain or if unknown
    */
   @Nullable
-  public String getBundle() {
-    return bundle;
+  public String getDomain() {
+    return domain;
   }
 
   /**
@@ -156,7 +173,7 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
    *     </code> block at this location; <code>false</code> if it cannot
    */
   public boolean canDoPrivilegedBlocks(Debug debug) {
-    return !(isThirdPartyBundle() || isThirdPartyClass() || isProxyClass(debug));
+    return !(isThirdPartyDomain(debug) || isThirdPartyClass() || isProxyClass(debug));
   }
 
   /**
@@ -166,39 +183,48 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
    *     <code>false</code> if not
    */
   public boolean isDoPrivilegedBlock() {
-    return ((bundle == null) && location.startsWith("java.security.AccessController.doPrivileged"));
+    return ((domain == null) && location.startsWith("java.security.AccessController.doPrivileged"));
   }
 
   /**
    * Checks if this location corresponds to a code known to perform a <code>doPrivileged()</code>
    * block in the code on behalf of its caller by re-arranging the access control context.
    *
+   * <p><i>Note:</i> These locations are confirmed to get the current context using <code>
+   * AccessController.getContext()</code> and pass it along as is directly to a <code>
+   * AccessController.doPrivileged()</code> method as opposed to getting it from somewhere else. The
+   * difference is that the context being passed in is from the stack at that point and not from
+   * something unrelated and as such, we can treat it as being part of the stack dcontext of domains
+   * instead of combined domains.
+   *
    * @return <code>true</code> if this location corresponds to a <code>doPrivileged()</code> block;
    *     <code>false</code> if not
    */
-  public boolean isCallingDoPrivilegedBlockOnBehalfOf() {
-    return ((bundle == null) && location.equals("javax.security.auth.Subject:422"));
+  public boolean isCallingDoPrivilegedBlockOnBehalfOfCaller() {
+    return ((domain == null) && location.equals("javax.security.auth.Subject:422"));
   }
 
   /**
    * Checks if this location has permissions based on the specified set of privileged bundles.
    *
-   * @param privilegedBundles the set of privileged bundles to checked against
-   * @return <code>true</code> if this location corresponds to <code>bundle-0</code> or if it's
-   *     corresponding bundle is included in the provided set of privileged bundles or if <code>
-   *     privilegedBundles</code> is <code>null</code>; <code>false</code> otherwise
+   * @param privilegedDomains the set of privileged bundle names or domain locations to checked
+   *     against
+   * @return <code>true</code> if this location corresponds to <code>bundle-0</code> or the boot
+   *     domain or is unknown or if it's corresponding bundle name or domain location is included in
+   *     the provided set of privileged domains or if <code>privilegedDomains</code> is <code>null
+   *     </code>; <code>false</code> otherwise
    */
-  public boolean isPrivileged(@Nullable Set<String> privilegedBundles) {
-    if (privilegedBundles == null) {
+  public boolean isPrivileged(@Nullable Set<String> privilegedDomains) {
+    if (privilegedDomains == null) {
       return true;
     }
-    // bundle=0 always has all permissions
-    return (bundle == null) || privilegedBundles.contains(bundle);
+    // bundle=0/boot domain always has all permissions
+    return (domain == null) || privilegedDomains.contains(domain);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bundle, location);
+    return Objects.hash(domain, location);
   }
 
   @Override
@@ -208,7 +234,7 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
     } else if (obj instanceof StackFrameInformation) {
       final StackFrameInformation f = (StackFrameInformation) obj;
 
-      return Objects.equals(bundle, f.bundle) && Objects.equals(location, f.location);
+      return Objects.equals(domain, f.domain) && Objects.equals(location, f.location);
     }
     return false;
   }
@@ -218,8 +244,8 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
     if (f == this) {
       return 0;
     }
-    if (bundle != f.bundle) {
-      final int d = (bundle == null) ? -1 : bundle.compareTo(f.bundle);
+    if (domain != f.domain) {
+      final int d = (domain == null) ? -1 : domain.compareTo(f.domain);
 
       if (d != 0) {
         return d;
@@ -230,62 +256,69 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
 
   /**
    * Provides a string representation for this location based on the given set of privileged
-   * bundles.
+   * domains.
    *
-   * <p>The returned string will be prefixed with <code>*</code> if the corresponding bundle doesn't
+   * <p>The returned string will be prefixed with <code>*</code> if the corresponding domain doesn't
    * have privileges.
    *
-   * @param privilegedBundles the set of privileged bundles to checked against
+   * @param osgi <code>true</code> if debugging an OSGi container; <code>false</code> otherwise
+   * @param privilegedDomains the set of privileged bundle names or domain locations to checked
+   *     against
    * @return a corresponding string representation with prefixed privileged information
    */
-  public String toString(@Nullable Set<String> privilegedBundles) {
-    final String p = (isPrivileged(privilegedBundles) ? "" : "*");
+  public String toString(boolean osgi, @Nullable Set<String> privilegedDomains) {
+    final String p = (isPrivileged(privilegedDomains) ? "" : "*");
+    final String d =
+        ((domain != null)
+            ? domain
+            : (osgi ? StackFrameInformation.BUNDLE0 : StackFrameInformation.BOOT_DOMAIN));
 
-    if (bundle != null) {
-      return p + bundle + "(" + location + ")";
-    } else {
-      return p + StackFrameInformation.BUNDLE0 + "(" + location + ")";
-    }
+    return p + d + "(" + location + ") <" + classOrInstanceAtLocation + '>';
   }
 
   @Override
   public String toString() {
-    return toString(null);
+    return toString(false, null);
   }
 
-  private boolean isThirdPartyBundle() {
-    return (bundle == null)
-        || StackFrameInformation.THIRD_PARTY_PREFIXES.stream().anyMatch(bundle::startsWith);
+  private boolean isThirdPartyDomain(Debug debug) {
+    if (domain == null) {
+      return true;
+    } else if (debug.isOSGi()) {
+      return StackFrameInformation.THIRD_PARTY_PREFIXES.stream().anyMatch(domain::startsWith);
+    }
+    return StackFrameInformation.THIRD_PARTY_PATTERNS
+        .stream()
+        .map(p -> p.matcher(domain))
+        .anyMatch(Matcher::matches);
   }
 
   private boolean isThirdPartyClass() {
-    return (location != null)
-        && StackFrameInformation.THIRD_PARTY_PREFIXES.stream().anyMatch(location::startsWith);
+    // check the class at the location (i.e. the source class) as opposed to the instance class
+    // (i.e. thisObject) as the later could be a non-3rd party class extending a 3rd-party class and
+    // this stack frame location could be located inside that 3rd party base class
+    return StackFrameInformation.THIRD_PARTY_PREFIXES
+        .stream()
+        .anyMatch(locationClassName::startsWith);
   }
 
   private boolean isProxyClass(Debug debug) {
-    return StackFrameInformation.PROXIES
-        .stream()
-        .anyMatch(p -> debug.reflection().isInstance(p, thisObject));
-  }
+    final ReflectionUtil reflection = debug.reflection();
 
-  /** Line processors for returning set of strings while trimming and ignoring comment lines. */
-  private static class SetProcessor implements LineProcessor<Set<String>> {
-    private final Set<String> result = new HashSet<>();
-
-    @Override
-    public boolean processLine(String line) throws IOException {
-      final String trimmed = line.trim();
-
-      if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
-        result.add(trimmed);
+    if (thisObject != null) {
+      if (StackFrameInformation.PROXIES
+          .stream()
+          .anyMatch(p -> reflection.isInstance(p, thisObject))) {
+        return true;
       }
-      return true;
     }
-
-    @Override
-    public Set<String> getResult() {
-      return Collections.unmodifiableSet(result);
+    if (locationClass != null) {
+      // although unlikely that a normal class would extend a proxy generated class, let's still
+      // check for it
+      return StackFrameInformation.PROXIES
+          .stream()
+          .anyMatch(p -> reflection.isAssignableFrom(p, locationClass));
     }
+    return false;
   }
 }

--- a/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/api/StackFrameInformation.java
@@ -70,6 +70,14 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
       Resources.readLines(StackFrameInformation.class, "proxies.txt");
 
   /**
+   * Set of code location patterns known to perform a <code>doPrivileged()</code> block in the code
+   * on behalf of its caller by re-arranging the access control context.
+   */
+  private static final List<Pattern> DO_PRIVILEGED_ON_BEHALF_PATTERNS =
+      Resources.readLines(
+          StackFrameInformation.class, "do-privileged-on-behalf-patterns.txt", Pattern::compile);
+
+  /**
    * The bundle name or domain location corresponding to this stack frame or <code>null</code> if it
    * corresponds to <code>bundle-0</code> or the boot domain or if unknown.
    */
@@ -202,7 +210,11 @@ public class StackFrameInformation implements Comparable<StackFrameInformation> 
    *     <code>false</code> if not
    */
   public boolean isCallingDoPrivilegedBlockOnBehalfOfCaller() {
-    return ((domain == null) && location.equals("javax.security.auth.Subject:422"));
+    return ((domain == null)
+        && StackFrameInformation.DO_PRIVILEGED_ON_BEHALF_PATTERNS
+            .stream()
+            .map(p -> p.matcher(location))
+            .anyMatch(Matcher::matches));
   }
 
   /**

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
@@ -13,10 +13,12 @@
  */
 package org.codice.acdebugger.breakpoints;
 
-import com.sun.jdi.ArrayReference;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.request.EventRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ArrayReference; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.request.EventRequest; // NOSONAR
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -30,7 +32,6 @@ import org.codice.acdebugger.impl.BreakpointLocation;
  * Defines a breakpoint processor capable of intercepting security exceptions in the access
  * controller before they get thrown out.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class AccessControlContextCheckBreakpointProcessor implements BreakpointProcessor {
   @Override
   public Stream<BreakpointLocation> locations() {

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
@@ -55,7 +55,7 @@ public class AccessControlContextCheckBreakpointProcessor implements BreakpointP
     final SecurityCheckInformation security =
         new SecurityCheckInformation(debug, context, local_i, permission);
 
-    if (security.getFailedBundle() != null) {
+    if (security.getFailedDomain() != null) {
       if (!security.isAcceptable()) {
         // check if we have only one solution and that solution is to only grant permission(s)
         // (no privileged blocks) in which case we shall cache them to avoid going through all
@@ -64,18 +64,18 @@ public class AccessControlContextCheckBreakpointProcessor implements BreakpointP
 
         if (solutions.size() == 1) {
           final SecuritySolution solution = solutions.get(0);
-          final Set<String> grantedBundles = solution.getGrantedBundles();
+          final Set<String> grantedDomains = solution.getGrantedDomains();
 
-          if (!grantedBundles.isEmpty() && solution.getDoPrivilegedLocations().isEmpty()) {
+          if (!grantedDomains.isEmpty() && solution.getDoPrivilegedLocations().isEmpty()) {
             solution
-                .getGrantedBundles()
-                .forEach(b -> debug.permissions().grant(b, solution.getPermissions()));
+                .getGrantedDomains()
+                .forEach(d -> debug.permissions().grant(d, solution.getPermissions()));
           }
         }
       }
       debug.record(security);
     } // else - could be caused because we already processed something and artificially granted a
-    //          bundle the missing permissions we use in the ctor to determine if bundles have
+    //          domain the missing permissions we use in the ctor to determine if domains have
     //          permissions so even if the VM tells us there was an exception, we skip over it right
     //          away
     if (!debug.isFailing() && debug.isContinuous() && !security.isAcceptable()) {

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/AccessControlContextCheckBreakpointProcessor.java
@@ -41,7 +41,7 @@ public class AccessControlContextCheckBreakpointProcessor implements BreakpointP
 
   @Override
   public EventRequest createRequest(Debug debug, BreakpointLocation l) throws Exception {
-    return debug.getEventRequestManager().createBreakpointRequest(l.getLocation());
+    return debug.eventRequestManager().createBreakpointRequest(l.getLocation());
   }
 
   @Override

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/BackdoorProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/BackdoorProcessor.java
@@ -13,10 +13,12 @@
  */
 package org.codice.acdebugger.breakpoints;
 
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.event.MethodExitEvent;
-import com.sun.jdi.request.EventRequest;
-import com.sun.jdi.request.MethodExitRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.event.MethodExitEvent; // NOSONAR
+import com.sun.jdi.request.EventRequest; // NOSONAR
+import com.sun.jdi.request.MethodExitRequest; // NOSONAR
 import java.util.stream.Stream;
 import org.codice.acdebugger.api.BreakpointProcessor;
 import org.codice.acdebugger.api.Debug;
@@ -25,7 +27,6 @@ import org.codice.acdebugger.impl.BreakpointInfo;
 import org.codice.acdebugger.impl.BreakpointLocation;
 
 /** Breakpoint processor capable of connecting to the backdoor bundle in the attached VM. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class BackdoorProcessor implements BreakpointProcessor {
   @Override
   public Stream<BreakpointLocation> locations() {

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/BackdoorProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/BackdoorProcessor.java
@@ -38,7 +38,7 @@ public class BackdoorProcessor implements BreakpointProcessor {
     if (debug.backdoor().init(debug)) { // we are initialized or we managed to initialize
       return null;
     }
-    final MethodExitRequest request = debug.getEventRequestManager().createMethodExitRequest();
+    final MethodExitRequest request = debug.eventRequestManager().createMethodExitRequest();
 
     request.addClassFilter(location.getClassReference());
     return request;
@@ -46,7 +46,7 @@ public class BackdoorProcessor implements BreakpointProcessor {
 
   @Override
   public void process(BreakpointInfo info, Debug debug) throws Exception {
-    final MethodExitEvent event = (MethodExitEvent) debug.getEvent();
+    final MethodExitEvent event = (MethodExitEvent) debug.event();
     final ThreadReference thread = event.thread();
 
     debug.backdoor().init(debug, thread.frame(0).thisObject());

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/HasListenServicePermissionBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/HasListenServicePermissionBreakpointProcessor.java
@@ -41,7 +41,7 @@ public class HasListenServicePermissionBreakpointProcessor implements Breakpoint
 
   @Override
   public EventRequest createRequest(Debug debug, BreakpointLocation l) throws Exception {
-    return debug.getEventRequestManager().createBreakpointRequest(l.getLocation());
+    return debug.eventRequestManager().createBreakpointRequest(l.getLocation());
   }
 
   @Override

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/HasListenServicePermissionBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/HasListenServicePermissionBreakpointProcessor.java
@@ -13,9 +13,11 @@
  */
 package org.codice.acdebugger.breakpoints;
 
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.request.EventRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.request.EventRequest; // NOSONAR
 import java.util.Set;
 import java.util.stream.Stream;
 import org.codice.acdebugger.api.BreakpointProcessor;
@@ -29,7 +31,6 @@ import org.codice.acdebugger.impl.BreakpointLocation;
  *
  * <p><i>Note:</i> Verified with org.eclipse.osgi 3.12.50.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class HasListenServicePermissionBreakpointProcessor implements BreakpointProcessor {
   @Override
   public final Stream<BreakpointLocation> locations() {

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
@@ -67,7 +67,7 @@ public class ImpliesBreakpointProcessor implements BreakpointProcessor {
 
   @Override
   public EventRequest createRequest(Debug debug, BreakpointLocation l) throws Exception {
-    return debug.getEventRequestManager().createBreakpointRequest(l.getLocation());
+    return debug.eventRequestManager().createBreakpointRequest(l.getLocation());
   }
 
   @SuppressWarnings({

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/ImpliesBreakpointProcessor.java
@@ -13,11 +13,13 @@
  */
 package org.codice.acdebugger.breakpoints;
 
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
 import com.google.common.collect.ImmutableSet;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.request.EventRequest;
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.request.EventRequest; // NOSONAR
 import java.security.Permission;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,7 +34,6 @@ import org.codice.acdebugger.impl.BreakpointLocation;
  * Old version of a breakpoint processor that was attempting to intercept all calls to {@link
  * java.security.ProtectionDomain#implies(Permission)}.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class ImpliesBreakpointProcessor implements BreakpointProcessor {
   private static final Set<BreakpointLocation> LOCATIONS =
       ImmutableSet.of(

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/ReadDebugIndex.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/ReadDebugIndex.java
@@ -13,12 +13,14 @@
  */
 package org.codice.acdebugger.breakpoints;
 
-import com.sun.jdi.IncompatibleThreadStateException;
-import com.sun.jdi.IntegerValue;
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.ThreadReference;
-import com.sun.jdi.Value;
-import com.sun.jdi.VirtualMachine;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.IncompatibleThreadStateException; // NOSONAR
+import com.sun.jdi.IntegerValue; // NOSONAR
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.ThreadReference; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
+import com.sun.jdi.VirtualMachine; // NOSONAR
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -29,10 +31,7 @@ import java.lang.reflect.Method;
  * Class used to read the current index in the access controller were the security exception is
  * being thrown.
  */
-@SuppressWarnings({
-  "squid:S1191", /* Using the Java debugger API */
-  "squid:S1148" /* this is a console application */
-})
+@SuppressWarnings("squid:S1148" /* this is a console application */)
 class ReadDebugIndex {
   private static final byte INT_BYTE_SIG = (byte) 73;
   private static Class<?> slotInfoClass;

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityCheckInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityCheckInformation.java
@@ -13,15 +13,17 @@
  */
 package org.codice.acdebugger.breakpoints;
 
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
 import com.google.common.base.Charsets;
 import com.google.common.collect.Ordering;
 import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
-import com.sun.jdi.ArrayReference;
-import com.sun.jdi.Location;
-import com.sun.jdi.ObjectReference;
-import com.sun.jdi.StackFrame;
-import com.sun.jdi.Value;
+import com.sun.jdi.ArrayReference; // NOSONAR
+import com.sun.jdi.Location; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
+import com.sun.jdi.StackFrame; // NOSONAR
+import com.sun.jdi.Value; // NOSONAR
 import java.io.IOError;
 import java.io.IOException;
 import java.security.Permission;
@@ -46,7 +48,6 @@ import org.codice.acdebugger.api.StackFrameInformation;
  * During analysis, it is also used to compute and report possible security solutions to the
  * security failure.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 class SecurityCheckInformation extends SecuritySolution implements SecurityFailure {
   /**
    * List of patterns to match security check information that should be considered acceptable
@@ -574,7 +575,7 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
   }
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
-  protected void dumpPermission() {
+  private void dumpPermission() {
     if (isAcceptable()) {
       System.out.println(ACDebugger.PREFIX + "Acceptable permissions:");
       System.out.println(ACDebugger.PREFIX + "    " + getAcceptablePermissions());
@@ -587,7 +588,7 @@ class SecurityCheckInformation extends SecuritySolution implements SecurityFailu
   }
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
-  protected void dumpHowToFix(boolean osgi) {
+  private void dumpHowToFix(boolean osgi) {
     if (!grantedDomains.isEmpty()) {
       final String ds = (grantedDomains.size() == 1) ? "" : "s";
       final String ps = (permissionInfos.size() == 1) ? "" : "s";

--- a/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/breakpoints/SecurityServicePermissionImpliedInformation.java
@@ -67,7 +67,7 @@ class SecurityServicePermissionImpliedInformation extends SecuritySolution
 
   @SuppressWarnings("squid:S106" /* this is a console application */)
   @Override
-  public void dump(String prefix) {
+  public void dump(boolean osgi, String prefix) {
     final String first = prefix + "IMPLIED PERMISSION FAILURE";
 
     System.out.println(ACDebugger.PREFIX);
@@ -86,7 +86,7 @@ class SecurityServicePermissionImpliedInformation extends SecuritySolution
     System.out.println(ACDebugger.PREFIX);
     System.out.println(ACDebugger.PREFIX + "SOLUTIONS");
     System.out.println(ACDebugger.PREFIX + "---------");
-    print();
+    print(osgi);
   }
 
   @Override

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Backdoor.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Backdoor.java
@@ -13,11 +13,13 @@
  */
 package org.codice.acdebugger.impl;
 
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
 import com.google.gson.reflect.TypeToken;
-import com.sun.jdi.ArrayReference;
-import com.sun.jdi.ClassType;
-import com.sun.jdi.Method;
-import com.sun.jdi.ObjectReference;
+import com.sun.jdi.ArrayReference; // NOSONAR
+import com.sun.jdi.ClassType; // NOSONAR
+import com.sun.jdi.Method; // NOSONAR
+import com.sun.jdi.ObjectReference; // NOSONAR
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -32,7 +34,6 @@ import org.codice.acdebugger.common.JsonUtils;
 import org.codice.acdebugger.common.ServicePermissionInfo;
 
 /** This class provides access to the backdoor class running inside the attached VM. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class Backdoor {
   public static final String CLASS_SIGNATURE = "Lorg/codice/acdebugger/backdoor/Backdoor;";
 
@@ -92,7 +93,7 @@ public class Backdoor {
           reflection.findMethod(
               backdoorReference.referenceType(),
               "getDomain",
-              "(Ljava/lang/Object;)Ljava/lang/String;");
+              Backdoor.METHOD_SIGNATURE_OBJ_ARG_STRING_RESULT);
       this.getDomainInfo =
           reflection.findMethod(
               backdoorReference.referenceType(),

--- a/debugger/src/main/java/org/codice/acdebugger/impl/BreakpointInfo.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/BreakpointInfo.java
@@ -13,12 +13,13 @@
  */
 package org.codice.acdebugger.impl;
 
-import com.sun.jdi.request.EventRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.request.EventRequest; // NOSONAR
 import org.codice.acdebugger.api.BreakpointProcessor;
 import org.codice.acdebugger.api.Debug;
 
 /** This class provides information about a current breakpoint registered with the debugger. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class BreakpointInfo {
   private final EventRequest request;
   private final BreakpointProcessor processor;

--- a/debugger/src/main/java/org/codice/acdebugger/impl/BreakpointLocation.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/BreakpointLocation.java
@@ -13,13 +13,14 @@
  */
 package org.codice.acdebugger.impl;
 
-import com.sun.jdi.AbsentInformationException;
-import com.sun.jdi.Location;
-import com.sun.jdi.ReferenceType;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.AbsentInformationException; // NOSONAR
+import com.sun.jdi.Location; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
 import javax.annotation.Nullable;
 
 /** This class keeps track of a location in the code where we want to debug. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class BreakpointLocation {
   private final String classSignature;
   private final String method;

--- a/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
@@ -61,7 +61,7 @@ public class DebugContext {
    *
    * @return the backdoor utility
    */
-  public Backdoor getBackdoor() {
+  public Backdoor backdoor() {
     return backdoor;
   }
 

--- a/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/DebugContext.java
@@ -66,7 +66,7 @@ public class DebugContext {
   }
 
   /**
-   * Accesses system properties util functionnality.
+   * Accesses system properties util functionality.
    *
    * @return a system properties utility for the attached VM
    */

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
@@ -13,24 +13,26 @@
  */
 package org.codice.acdebugger.impl;
 
-import com.sun.jdi.Bootstrap;
-import com.sun.jdi.Method;
-import com.sun.jdi.ReferenceType;
-import com.sun.jdi.VirtualMachine;
-import com.sun.jdi.VirtualMachineManager;
-import com.sun.jdi.connect.AttachingConnector;
-import com.sun.jdi.connect.Connector.Argument;
-import com.sun.jdi.connect.IllegalConnectorArgumentsException;
-import com.sun.jdi.event.Event;
-import com.sun.jdi.event.EventIterator;
-import com.sun.jdi.event.EventQueue;
-import com.sun.jdi.event.EventSet;
-import com.sun.jdi.event.LocatableEvent;
-import com.sun.jdi.event.VMDisconnectEvent;
-import com.sun.jdi.request.BreakpointRequest;
-import com.sun.jdi.request.ClassPrepareRequest;
-import com.sun.jdi.request.EventRequest;
-import com.sun.jdi.request.EventRequestManager;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.Bootstrap; // NOSONAR
+import com.sun.jdi.Method; // NOSONAR
+import com.sun.jdi.ReferenceType; // NOSONAR
+import com.sun.jdi.VirtualMachine; // NOSONAR
+import com.sun.jdi.VirtualMachineManager; // NOSONAR
+import com.sun.jdi.connect.AttachingConnector; // NOSONAR
+import com.sun.jdi.connect.Connector.Argument; // NOSONAR
+import com.sun.jdi.connect.IllegalConnectorArgumentsException; // NOSONAR
+import com.sun.jdi.event.Event; // NOSONAR
+import com.sun.jdi.event.EventIterator; // NOSONAR
+import com.sun.jdi.event.EventQueue; // NOSONAR
+import com.sun.jdi.event.EventSet; // NOSONAR
+import com.sun.jdi.event.LocatableEvent; // NOSONAR
+import com.sun.jdi.event.VMDisconnectEvent; // NOSONAR
+import com.sun.jdi.request.BreakpointRequest; // NOSONAR
+import com.sun.jdi.request.ClassPrepareRequest; // NOSONAR
+import com.sun.jdi.request.EventRequest; // NOSONAR
+import com.sun.jdi.request.EventRequestManager; // NOSONAR
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -46,7 +48,6 @@ import org.codice.acdebugger.api.BreakpointProcessor;
 import org.codice.acdebugger.api.Debug;
 
 /** This class provides the main implementation for processing breakpoint requests/callbacks. */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class Debugger {
   private static final String INFO_KEY = "info";
 

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
@@ -85,6 +85,15 @@ public class Debugger {
   }
 
   /**
+   * Sets wether or not we are debugging an OSGi system.
+   *
+   * @param osgi <code>true</code> if we are debugging an OSGi system; <code>false</code> if not
+   */
+  public void setOSGi(boolean osgi) {
+    context.setOSGi(osgi);
+  }
+
+  /**
    * Sets the continuous mode for the debugger in which case it will not fail any security
    * exceptions detected and accumulate and report on all occurrences or if it will stop when the
    * first security failure is detected.
@@ -94,7 +103,7 @@ public class Debugger {
    *     detected security failure
    */
   public void setContinuous(boolean continuous) {
-    context.setContinuousMode(continuous);
+    context.setContinuous(continuous);
   }
 
   /**
@@ -172,12 +181,12 @@ public class Debugger {
     map.put(HOST_KEY, hostArg);
     this.debug = new DebugImpl(context, connector.attach(map));
     debug.virtualMachine().setDebugTraceMode(VirtualMachine.TRACE_NONE);
+    System.out.println(ACDebugger.PREFIX);
     System.out.println(ACDebugger.PREFIX + "Attached to:");
     Stream.of(debug.virtualMachine().description().split("[\r\n]"))
         .map("  "::concat)
         .map(ACDebugger.PREFIX::concat)
         .forEach(System.out::println);
-    System.out.println(ACDebugger.PREFIX);
     return this;
   }
 
@@ -226,8 +235,8 @@ public class Debugger {
       }
       line += " missing permissions";
     }
-    System.out.println(line);
     System.out.println(ACDebugger.PREFIX);
+    System.out.println(line);
     while (context.isRunning()) {
       final EventSet eventSet = evtQueue.remove();
       final EventIterator i = eventSet.eventIterator();

--- a/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/Debugger.java
@@ -258,7 +258,7 @@ public class Debugger {
   }
 
   private void add(BreakpointProcessor processor, BreakpointLocation l) throws Exception {
-    final EventRequestManager erm = debug.getEventRequestManager();
+    final EventRequestManager erm = debug.eventRequestManager();
     final ReferenceType clazz = debug.reflection().getClass(l.getClassSignature());
 
     if (clazz == null) {
@@ -310,7 +310,7 @@ public class Debugger {
         final PendingBreakpointInfo info = (PendingBreakpointInfo) oinfo;
 
         request.disable();
-        debug.getEventRequestManager().deleteEventRequest(request);
+        debug.eventRequestManager().deleteEventRequest(request);
         add(info.getProcessor(), info.getLocation());
       } else if (oinfo instanceof BreakpointInfo) {
         final String method = ((BreakpointInfo) oinfo).getLocation().getMethod();

--- a/debugger/src/main/java/org/codice/acdebugger/impl/PendingBreakpointInfo.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/PendingBreakpointInfo.java
@@ -13,14 +13,15 @@
  */
 package org.codice.acdebugger.impl;
 
-import com.sun.jdi.request.ClassPrepareRequest;
+// NOSONAR - squid:S1191 - Using the Java debugger API
+
+import com.sun.jdi.request.ClassPrepareRequest; // NOSONAR
 import org.codice.acdebugger.api.BreakpointProcessor;
 
 /**
  * Information about a pending breakpoint to register which is awaiting its corresponding class to
  * be loaded.
  */
-@SuppressWarnings("squid:S1191" /* Using the Java debugger API */)
 public class PendingBreakpointInfo {
   private final ClassPrepareRequest request;
   private final BreakpointProcessor processor;

--- a/debugger/src/main/java/org/codice/acdebugger/impl/SystemProperties.java
+++ b/debugger/src/main/java/org/codice/acdebugger/impl/SystemProperties.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.impl;
+
+import com.sun.jdi.ClassType;
+import com.sun.jdi.Method;
+import com.sun.jdi.ObjectReference;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import org.codice.acdebugger.ACDebugger;
+import org.codice.acdebugger.api.Debug;
+import org.codice.acdebugger.api.ReflectionUtil;
+import org.codice.acdebugger.common.PropertiesUtil;
+
+public class SystemProperties {
+  public static final String CLASS_SIGNATURE = "Ljava/lang/System;";
+
+  private static final String METHOD_SIGNATURE_STRING_ARG_STRING_RESULT =
+      "(Ljava/lang/String;)Ljava/lang/String;";
+
+  private ObjectReference systemPropertiesReference;
+
+  private Method getProperty;
+
+  private boolean initializing = false;
+
+  private Properties properties = null;
+
+  private PropertiesUtil util;
+
+  /**
+   * Initializes the backdoor.
+   *
+   * @param debug the current debug information
+   * @param systemPropertiesReference the system properties reference
+   */
+  public synchronized void init(Debug debug, ObjectReference systemPropertiesReference) {
+    if (systemPropertiesReference == null) {
+      throw new IllegalStateException("unable to locate system properties");
+    }
+    final ReflectionUtil reflection = debug.reflection();
+
+    try {
+      this.initializing = true;
+      this.systemPropertiesReference = systemPropertiesReference;
+      this.getProperty =
+          reflection.findMethod(
+              systemPropertiesReference.referenceType(),
+              "getProperty",
+              SystemProperties.METHOD_SIGNATURE_STRING_ARG_STRING_RESULT);
+      final Map<String, String> properties = new LinkedHashMap<>();
+
+      for (final String property : PropertiesUtil.PROPERTIES) {
+        final String value = reflection.invoke(systemPropertiesReference, getProperty, property);
+
+        if (value != null) {
+          properties.put(property, value);
+        }
+      }
+      final Properties props = new Properties();
+
+      props.putAll(properties);
+      this.properties = props;
+      this.util = new PropertiesUtil(this.properties);
+      System.out.println(ACDebugger.PREFIX);
+      System.out.println(ACDebugger.PREFIX + "System properties are initialized");
+      properties.forEach(
+          (p, v) -> System.out.println(ACDebugger.PREFIX + "    " + p + " = \"" + v + "\""));
+    } finally {
+      this.initializing = false;
+    }
+  }
+
+  /**
+   * Initializes the system properties by attempting to find its instance in the attached VM.
+   *
+   * @param debug the current debug information
+   * @return <code>true</code> if the backdoor is initialized; <code>false</code> if not
+   */
+  public synchronized boolean init(Debug debug) {
+    if (initializing) {
+      return false;
+    } else if (systemPropertiesReference == null) {
+      final ObjectReference ref =
+          debug
+              .reflection()
+              .classes(SystemProperties.CLASS_SIGNATURE)
+              .map(clazz -> getSystemProperties(debug, clazz))
+              .filter(Objects::nonNull)
+              .findFirst()
+              .orElse(null);
+
+      if (ref == null) {
+        return false;
+      }
+      init(debug, ref);
+    }
+    return true;
+  }
+
+  /**
+   * Compresses the specified strings by replacing occurrences of configured system properties.
+   *
+   * @param debug the current debug information
+   * @param s the string to compress
+   * @return the corresponding compressed string
+   */
+  public synchronized String compress(Debug debug, String s) {
+    findSystemProperties(debug); // make sure the system properties are enabled
+    return util.compress(s);
+  }
+
+  private synchronized void findSystemProperties(Debug debug) {
+    if (initializing) {
+      throw new IllegalStateException("system properties are initializing");
+    }
+    if (!init(debug)) {
+      throw new IllegalStateException("system properties is not initialized yet");
+    }
+  }
+
+  private ObjectReference getSystemProperties(Debug debug, ClassType clazz) {
+    try {
+      return debug.reflection().invokeStatic(clazz, "getProperties", "()Ljava/util/Properties;");
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/debugger/src/main/resources/do-privileged-on-behalf-patterns.txt
+++ b/debugger/src/main/resources/do-privileged-on-behalf-patterns.txt
@@ -1,0 +1,24 @@
+# Sets of location regex strings for code known to perform a <code>doPrivileged()</code> block in
+# the code on behalf of its caller by re-arranging the access control context.
+#
+# All of these are only considered if they are part of the boot domain or bundle-0.
+#
+# These locations are confirmed to get the current context using
+# <code>AccessController.getContext()</code> and pass it along as is directly to a
+# <code>AccessController.doPrivileged()</code> method as opposed to getting it from somewhere else.
+# The difference is that the context being passed in is from the stack at that point and not from
+# something unrelated and as such, we can treat it as being part of the stack context of domains
+# instead of combined domains.
+
+# Subject.doAs() is designed to execute a privileged action with the added context of the subject,
+# one is trying to do something as. It purposely retrieves the context at the point it is called
+# and combines the subject's attached context. The end result is that the stack break normally
+# created by calling doPrivileged() is ignored since all the contexts before are being re-combined.
+# So by identifying it here, the debugger can continue to consider these stack method calls during
+# its analysis and provide better solutions.
+# These are for JDK 8
+javax\.security\.auth\.Subject:359
+javax\.security\.auth\.Subject:421
+# These are for OpenSource JDK 11
+javax\.security\.auth\.Subject:360
+javax\.security\.auth\.Subject:422

--- a/debugger/src/main/resources/proxies.txt
+++ b/debugger/src/main/resources/proxies.txt
@@ -1,4 +1,5 @@
 # Sets of signatures for proxy classes. These are used as indicator of where we are shouldn't
 # provide solutions that consists in extending privileges using doPrivileged() blocks.
+
 Ljava/lang/reflect/Proxy;
 Lorg/apache/aries/proxy/weaving/WovenProxy;

--- a/debugger/src/main/resources/thirdparty-patterns.txt
+++ b/debugger/src/main/resources/thirdparty-patterns.txt
@@ -2,11 +2,11 @@
 # where we are shouldn't provide solutions that consists in extending privileges using
 # doPrivileged() blocks.
 
-jetty-deploy-.*\.jar
-jetty-http-.*\.jar
-jetty-server-.*\.jar
-jetty-servlet-.*\.jar
-jetty-util-.*\.jar
-jetty-webapp-.*\.jar
-jetty-xml-.*\.jar
-pro-grade-.*\.jar
+.*jetty-deploy-.*\.jar
+.*jetty-http-.*\.jar
+.*jetty-server-.*\.jar
+.*jetty-servlet-.*\.jar
+.*jetty-util-.*\.jar
+.*jetty-webapp-.*\.jar
+.*jetty-xml-.*\.jar
+.*pro-grade-.*\.jar

--- a/debugger/src/main/resources/thirdparty-patterns.txt
+++ b/debugger/src/main/resources/thirdparty-patterns.txt
@@ -1,0 +1,12 @@
+# Sets of regex domain locations for when debugging non-OSGi VMs. These are used as indicator of
+# where we are shouldn't provide solutions that consists in extending privileges using
+# doPrivileged() blocks.
+
+jetty-deploy-.*\.jar
+jetty-http-.*\.jar
+jetty-server-.*\.jar
+jetty-servlet-.*\.jar
+jetty-util-.*\.jar
+jetty-webapp-.*\.jar
+jetty-xml-.*\.jar
+pro-grade-.*\.jar

--- a/debugger/src/main/resources/thirdparty-prefixes.txt
+++ b/debugger/src/main/resources/thirdparty-prefixes.txt
@@ -3,8 +3,10 @@
 # doPrivileged() blocks.
 
 com.fasterxml
-javax.servlet
-javax.servlet-api
+com.sun.
+java.
+javax.
+jdk.internal.
 org.apache
 org.boon
 org.eclipse
@@ -14,3 +16,4 @@ org.knopflerfish
 org.ops4j
 org.osgi
 org.springframework
+sun.

--- a/docs/debug.MD
+++ b/docs/debug.MD
@@ -5,266 +5,269 @@ Here is an example of debug output:
 AC Debugger: 0136 - ACCESS CONTROL PERMISSION FAILURE
 AC Debugger: ========================================
 AC Debugger: Permission:
-AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
-AC Debugger:  Context:
-AC Debugger:       bundle-0
-AC Debugger:       org.apache.commons.io
-AC Debugger:   --> *platform-migration
-AC Debugger:  Stack:
-AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
-AC Debugger:       at bundle-0(java.security.AccessController:884)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
-AC Debugger:       at bundle-0(java.io.File:844)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-AC Debugger:       at bundle-0(java.io.File:1291)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-AC Debugger:   --> at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:      ----------------------------------------------------------
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-AC Debugger:       at bundle-0(java.util.Iterator:116)
-AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
-AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:       at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-AC Debugger:       at bundle-0(java.lang.Thread:748)
-AC Debugger:  
-AC Debugger:  OPTION 1
-AC Debugger:  --------
-AC Debugger:  Permission:
-AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
-AC Debugger:  Granting permission to bundles:
-AC Debugger:      platform-migration
-AC Debugger:  Extending privileges at:
-AC Debugger:      platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:  Context:
-AC Debugger:       bundle-0
-AC Debugger:       org.apache.commons.io
-AC Debugger:       platform-migration
-AC Debugger:  Stack:
-AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
-AC Debugger:       at bundle-0(java.security.AccessController:884)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
-AC Debugger:       at bundle-0(java.io.File:844)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-AC Debugger:       at bundle-0(java.io.File:1291)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction))
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:      ----------------------------------------------------------
-AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-AC Debugger:       at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-AC Debugger:       at bundle-0(java.util.Iterator:116)
-AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
-AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-AC Debugger:       at bundle-0(java.lang.Thread:748)
+AC Debugger:     java.io.FilePermission "${ddf.home.perm}security${/}default.policy", "read"
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:      org.apache.commons.io
+AC Debugger:  --> *platform-migration
+AC Debugger:      *platform-migratable-api
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=16228)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.io.File:844) <instance of java.io.File(id=16232)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71) <instance of org.apache.commons.io.filefilter.DirectoryFileFilter(id=11809)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56) <instance of org.apache.commons.io.filefilter.NotFileFilter(id=16233)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128) <instance of org.apache.commons.io.filefilter.AndFileFilter(id=16234)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123) <instance of org.apache.commons.io.filefilter.OrFileFilter(id=16235)>
+AC Debugger:      at bundle-0(java.io.File:1291) <instance of java.io.File(id=16236)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:473) <class of org.apache.commons.io.FileUtils>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:524) <class of org.apache.commons.io.FileUtils>
+AC Debugger:  --> at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346.get()+8) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346(id=16238)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=16239)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:     ----------------------------------------------------------
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104) <instance of org.codice.ddf.security.migratable.impl.SecurityMigratable(id=16158)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955.apply(java.lang.Object)+4) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955(id=11569)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline$3$1:193) <instance of java.util.stream.ReferencePipeline$3$1(id=11570)>
+AC Debugger:      at bundle-0(java.util.Iterator:116) <instance of java.util.LinkedHashMap$LinkedValueIterator(id=11571)>
+AC Debugger:      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801) <instance of java.util.Spliterators$IteratorSpliterator(id=11573)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:481) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:471) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708) <instance of java.util.stream.ReduceOps$4(id=11577)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:234) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline:510) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl(id=11205)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:228) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:278) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107.get()+12) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107(id=11134)>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=11135)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:      at *platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485.call()+4) <instance of org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485(id=11139)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=11143)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182) <instance of org.codice.ddf.security.common.Security(id=11144)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84) <instance of org.apache.karaf.shell.impl.action.command.ActionCommand(id=11145)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266) <instance of java.util.concurrent.FutureTask(id=11152)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142) <instance of java.util.concurrent.ThreadPoolExecutor(id=11154)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617) <instance of java.util.concurrent.ThreadPoolExecutor$Worker(id=11156)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='pipe-migration:export', id=8571)>
 AC Debugger: 
-AC Debugger:  OPTION 2
-AC Debugger:  --------
-AC Debugger:  Permission:
-AC Debugger:      java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read"
-AC Debugger:  Granting permission to bundles:
+AC Debugger: OPTION 1
+AC Debugger: --------
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${ddf.home.perm}security${/}default.policy", "read"
+AC Debugger: Granting permission to bundle:
+AC Debugger:     platform-migration
+AC Debugger: Extending privileges at:
+AC Debugger:     platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:      org.apache.commons.io
+AC Debugger:      platform-migration
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=16228)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.io.File:844) <instance of java.io.File(id=16232)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71) <instance of org.apache.commons.io.filefilter.DirectoryFileFilter(id=11809)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56) <instance of org.apache.commons.io.filefilter.NotFileFilter(id=16233)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128) <instance of org.apache.commons.io.filefilter.AndFileFilter(id=16234)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123) <instance of org.apache.commons.io.filefilter.OrFileFilter(id=16235)>
+AC Debugger:      at bundle-0(java.io.File:1291) <instance of java.io.File(id=16236)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:473) <class of org.apache.commons.io.FileUtils>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:524) <class of org.apache.commons.io.FileUtils>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)) <class of java.security.AccessController>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:     ----------------------------------------------------------
+AC Debugger:      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346.get()+8) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346(id=16238)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=16239)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104) <instance of org.codice.ddf.security.migratable.impl.SecurityMigratable(id=16158)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955.apply(java.lang.Object)+4) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955(id=11569)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline$3$1:193) <instance of java.util.stream.ReferencePipeline$3$1(id=11570)>
+AC Debugger:      at bundle-0(java.util.Iterator:116) <instance of java.util.LinkedHashMap$LinkedValueIterator(id=11571)>
+AC Debugger:      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801) <instance of java.util.Spliterators$IteratorSpliterator(id=11573)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:481) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:471) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708) <instance of java.util.stream.ReduceOps$4(id=11577)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:234) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline:510) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl(id=11205)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:228) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:278) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107.get()+12) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107(id=11134)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=11135)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485.call()+4) <instance of org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485(id=11139)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=11143)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182) <instance of org.codice.ddf.security.common.Security(id=11144)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84) <instance of org.apache.karaf.shell.impl.action.command.ActionCommand(id=11145)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266) <instance of java.util.concurrent.FutureTask(id=11152)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142) <instance of java.util.concurrent.ThreadPoolExecutor(id=11154)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617) <instance of java.util.concurrent.ThreadPoolExecutor$Worker(id=11156)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='pipe-migration:export', id=8571)>
+AC Debugger: 
+AC Debugger: OPTION 2
+AC Debugger: --------
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${ddf.home.perm}security${/}default.policy", "read"
+AC Debugger: Granting permission to bundles:
+AC Debugger:     platform-migration
+AC Debugger:     platform-migratable-api
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:      org.apache.commons.io
 AC Debugger:      platform-migration
 AC Debugger:      platform-migratable-api
-AC Debugger:  Context:
-AC Debugger:       bundle-0
-AC Debugger:       org.apache.commons.io
-AC Debugger:       platform-migration
-AC Debugger:       platform-migratable-api
-AC Debugger:  Stack:
-AC Debugger:       at bundle-0(java.security.AccessControlContext:472)
-AC Debugger:       at bundle-0(java.security.AccessController:884)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:549)
-AC Debugger:       at bundle-0(java.lang.SecurityManager:888)
-AC Debugger:       at bundle-0(java.io.File:844)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123)
-AC Debugger:       at bundle-0(java.io.File:1291)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:473)
-AC Debugger:       at org.apache.commons.io(org.apache.commons.io.FileUtils:524)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:       at platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$462.135345875.get()+8)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:      ----------------------------------------------------------
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208)
-AC Debugger:       at platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207)
-AC Debugger:       at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$444.842134888.apply(java.lang.Object)+4)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline$3$1:193)
-AC Debugger:       at bundle-0(java.util.Iterator:116)
-AC Debugger:       at bundle-0(java.util.Spliterators$IteratorSpliterator:1801)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:481)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:471)
-AC Debugger:       at bundle-0(java.util.stream.ReduceOps$ReduceOp:708)
-AC Debugger:       at bundle-0(java.util.stream.AbstractPipeline:234)
-AC Debugger:       at bundle-0(java.util.stream.ReferencePipeline:510)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:226)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:276)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$408.1094074659.get()+12)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56)
-AC Debugger:       at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52)
-AC Debugger:       at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:160)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$376.1915231195.call()+4)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-AC Debugger:       at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182)
-AC Debugger:       at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-AC Debugger:       at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-AC Debugger:       at bundle-0(java.util.concurrent.FutureTask:266)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-AC Debugger:       at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-AC Debugger:       at bundle-0(java.lang.Thread:748)
-AC Debugger:  
-AC Debugger:  SOLUTIONS
-AC Debugger:  ---------
-AC Debugger:  {
-AC Debugger:      Add the following permission to the appropriate policy file:
-AC Debugger:          grant codeBase "file:/platform-migration" {
-AC Debugger:              permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
-AC Debugger:          }
-AC Debugger:      and add an AccessController.doPrivileged() block around:
-AC Debugger:          platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145)
-AC Debugger:  }
-AC Debugger:  {
-AC Debugger:      Add the following permission to the appropriate policy file:
-AC Debugger:          grant codeBase "file:/platform-migratable-api/platform-migration" {
-AC Debugger:              permission java.io.FilePermission "/projects/ddf-2.14.0-SNAPSHOT/security/default.policy", "read";
-AC Debugger:          }
-AC Debugger:  }
- ```
- 
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=16228)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=11120)>
+AC Debugger:      at bundle-0(java.io.File:844) <instance of java.io.File(id=16232)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.DirectoryFileFilter:71) <instance of org.apache.commons.io.filefilter.DirectoryFileFilter(id=11809)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.NotFileFilter:56) <instance of org.apache.commons.io.filefilter.NotFileFilter(id=16233)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.AndFileFilter:128) <instance of org.apache.commons.io.filefilter.AndFileFilter(id=16234)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.filefilter.OrFileFilter:123) <instance of org.apache.commons.io.filefilter.OrFileFilter(id=16235)>
+AC Debugger:      at bundle-0(java.io.File:1291) <instance of java.io.File(id=16236)>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:473) <class of org.apache.commons.io.FileUtils>
+AC Debugger:      at org.apache.commons.io(org.apache.commons.io.FileUtils:524) <class of org.apache.commons.io.FileUtils>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at platform-migratable-api(org.codice.ddf.migration.ExportMigrationContext:169) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:392) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:362) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346.get()+8) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl$$Lambda$577.1256736346(id=16238)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=16239)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:     ----------------------------------------------------------
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:358) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationEntryImpl:208) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at platform-migratable-api(org.codice.ddf.migration.ExportMigrationEntry:207) <instance of org.codice.ddf.configuration.migration.ExportMigrationEntryImpl(id=16237)>
+AC Debugger:      at *security-migratable(org.codice.ddf.security.migratable.impl.SecurityMigratable:104) <instance of org.codice.ddf.security.migratable.impl.SecurityMigratable(id=16158)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:195) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955.apply(java.lang.Object)+4) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl$$Lambda$557.633171955(id=11569)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline$3$1:193) <instance of java.util.stream.ReferencePipeline$3$1(id=11570)>
+AC Debugger:      at bundle-0(java.util.Iterator:116) <instance of java.util.LinkedHashMap$LinkedValueIterator(id=11571)>
+AC Debugger:      at bundle-0(java.util.Spliterators$IteratorSpliterator:1801) <instance of java.util.Spliterators$IteratorSpliterator(id=11573)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:481) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:471) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReduceOps$ReduceOp:708) <instance of java.util.stream.ReduceOps$4(id=11577)>
+AC Debugger:      at bundle-0(java.util.stream.AbstractPipeline:234) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at bundle-0(java.util.stream.ReferencePipeline:510) <instance of java.util.stream.ReferencePipeline$3(id=11576)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ExportMigrationManagerImpl:166) <instance of org.codice.ddf.configuration.migration.ExportMigrationManagerImpl(id=11205)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:228) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:278) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107.get()+12) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager$$Lambda$514.359595107(id=11134)>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils$1:56) <instance of org.codice.ddf.configuration.migration.AccessUtils$1(id=11135)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction)+-1) <class of java.security.AccessController>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.AccessUtils:52) <class of org.codice.ddf.configuration.migration.AccessUtils>
+AC Debugger:      at platform-migration(org.codice.ddf.configuration.migration.ConfigurationMigrationManager:162) <instance of org.codice.ddf.configuration.migration.ConfigurationMigrationManager(id=11133)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.ExportCommand:47) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485.call()+4) <instance of org.codice.ddf.migration.commands.MigrationCommand$$Lambda$459.2036866485(id=11139)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=11140)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=11143)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.security.common.Security:182) <instance of org.codice.ddf.security.common.Security(id=11144)>
+AC Debugger:      at *admin-core-migration-commands(org.codice.ddf.migration.commands.MigrationCommand:107) <instance of org.codice.ddf.migration.commands.ExportCommand(id=11136)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84) <instance of org.apache.karaf.shell.impl.action.command.ActionCommand(id=11145)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=11148)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386) <instance of org.apache.felix.gogo.runtime.Closure(id=11149)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at *org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59) <instance of org.apache.felix.gogo.runtime.Pipe(id=11150)>
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266) <instance of java.util.concurrent.FutureTask(id=11152)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142) <instance of java.util.concurrent.ThreadPoolExecutor(id=11154)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617) <instance of java.util.concurrent.ThreadPoolExecutor$Worker(id=11156)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='pipe-migration:export', id=8571)>
+AC Debugger: 
+AC Debugger: SOLUTIONS
+AC Debugger: ---------
+AC Debugger: {
+AC Debugger:     Add the following permission block to the appropriate policy file:
+AC Debugger:         grant codeBase "file:/platform-migration" {
+AC Debugger:             permission java.io.FilePermission "${ddf.home.perm}security${/}default.policy", "read";
+AC Debugger:         }
+AC Debugger:     and add an AccessController.doPrivileged() block around:
+AC Debugger:         platform-migration(org.codice.ddf.configuration.migration.ExportMigrationContextImpl:145) <instance of org.codice.ddf.configuration.migration.ExportMigrationContextImpl(id=16149)>
+AC Debugger: }
+AC Debugger: {
+AC Debugger:     Add the following permission block to the appropriate policy file:
+AC Debugger:         grant codeBase "file:/platform-migratable-api/platform-migration" {
+AC Debugger:             permission java.io.FilePermission "${ddf.home.perm}security${/}default.policy", "read";
+AC Debugger:         }
+AC Debugger: }
+```
+
 The first line `0136 - ACCESS CONTROL PERMISSION FAILURE` indicates this was the 136th failure detected and corresponds to an access control permission check. 
 Following that, we can see the permission or permissions involved in the failure and the state of the security context. 
-The security context is a stack of domains which in OSGi corresponds to bundles. 
+The security context is a stack of domains which in OSGi corresponds to bundles and for non-OSGi containers, it corresponds to the domain location. 
 The `*` is prefixed in front of any domain that is not currently granted the permission(s). 
 The `-->` is used to identify the domain in the context that is about to generate the failure.
-The next section provides information about the current stack. it will show the location in the code in between parenthesis and the name of the bundle the code is located in which will also be prefixed with a `*` if it is detected that the bundle is not granted the permission(s).
+The next section provides information about the current stack. 
+It will show the location in the code in between parenthesis and the name of the bundle or the domain codesource location where the code is located in which will also be prefixed with a `*` if it is detected that the bundle or domain is not granted the permission(s).
+At the end of each line in between `<>` we can find information about the runtime object (e.g. `instance of java.security.AccessControlContext(id=16228)>`) for instance methods or the class (e.g. `<class of java.security.AccessController>`) for static methods. 
 As in the context above, a line will show `-->` next to culprit which is responsible for the imminent failure.
 The stack will also show a break line (` ----------------------------------------------------------`) whenever a `doPrivileged()` block is detected. 
 This means that everything after the block is ignored by the security manager.
 
 After having provided information about the current failure, possible options or solutions will be printed out in a similar fashion. 
 Additional information will be provided to indicate what needs to be done. 
-For example the `Granting permissions to bundles:` section will list a set of bundles that are given the missing permission(s).
+For example the `Granting permissions to bundles:` or `Granting permissions to domains:` section will list a set of bundles or domains that are given the missing permission(s).
 The `Extending privileges at:` section is used to indicate lines in the code where one can introduce a `doPrivileged()` block to solve the issue at hand.
 The stack that will follow will show how it would appear if the option were implemented. There should no longer be any failure; thus, no `-->` will be seen.
 
@@ -275,129 +278,149 @@ Here is an example when an acceptable failure is detected:
 ```
 AC Debugger: 0141 - ACCEPTABLE ACCESS CONTROL PERMISSION FAILURE
 AC Debugger: ===================================================
-AC Debugger: Acceptable permission:
+AC Debugger: Acceptable permissions:
 AC Debugger:     REGEX: java\.io\.FilePermission ".*", "read"
 AC Debugger: Context:
 AC Debugger:      bundle-0
 AC Debugger:  --> *org.codice.thirdparty.tika-bundle
+AC Debugger:      *org.apache.tika.core
+AC Debugger:      *catalog-transformer-pdf
+AC Debugger:      *catalog-core-standardframework
+AC Debugger:      *catalog-rest-impl
+AC Debugger:      *catalog-ui-search
+AC Debugger:      *javax.servlet-api
+AC Debugger:      *org.eclipse.jetty.servlet
+AC Debugger:      *platform-filter-delegate
+AC Debugger:      *platform-filter-clientinfo
+AC Debugger:      *platform-filter-response
+AC Debugger:      *security-filter-authorization
+AC Debugger:      *security-filter-login
+AC Debugger:      *org.apache.cxf.cxf-rt-transports-http (combined)
 AC Debugger: Stack:
-AC Debugger:      at bundle-0(java.security.AccessControlContext:472)
-AC Debugger:      at bundle-0(java.security.AccessController:884)
-AC Debugger:      at bundle-0(java.lang.SecurityManager:549)
-AC Debugger:      at bundle-0(java.lang.SecurityManager:888)
-AC Debugger:      at bundle-0(java.io.File:814)
-AC Debugger:  --> at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.NativeFontDirFinder:47)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.FontFileFinder:75)
-AC Debugger:      at #*org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FileSystemFontProvider:214)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl$DefaultFontProvider:130)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:149)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:413)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:376)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:350)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:146)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:79)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:128)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:93)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.PDDocumentCatalog:109)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:598)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:545)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.text.PDFTextStripper:267)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDF2XHTML:117)
-AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDFParser:171)
-AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280)
-AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.AutoDetectParser:143)
-AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:75)
-AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:68)
-AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:229)
-AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:170)
-AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:153)
-AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.MetacardFactory:75)
-AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.OperationsMetacardSupport:156)
-AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.CreateOperations:141)
-AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.CatalogFrameworkImpl:237)
-AC Debugger:      at *catalog-rest-impl(Proxy657df4cb_72a9_4651_97be_9316fe1dabb9.create(ddf.catalog.content.operation.CreateStorageRequest)+58)
-AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:764)
-AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:727)
-AC Debugger:      at *catalog-ui-search(Proxye57e7ff3_143d_40a0_beef_f9bad6b72587.addDocument(java.util.List, javax.servlet.http.HttpServletRequest, java.lang.String, java.io.InputStream)+77)
-AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:375)
-AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:150)
-AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication$$Lambda$808.525212850.handle(spark.Request, spark.Response)+6)
-AC Debugger:      at *catalog-ui-search(spark.RouteImpl$1:61)
-AC Debugger:      at *catalog-ui-search(spark.http.matching.Routes:61)
-AC Debugger:      at *catalog-ui-search(spark.http.matching.MatcherFilter:130)
-AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.SparkServlet:146)
-AC Debugger:      at *javax.servlet-api(javax.servlet.http.HttpServlet:790)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHolder:840)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1772)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:98)
-AC Debugger:      at *platform-filter-clientinfo(org.codice.ddf.platform.filter.clientinfo.ClientInfoFilter:72)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *platform-filter-response(org.codice.ddf.platform.response.filter.ResponseFilter:96)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *security-filter-authorization(org.codice.ddf.security.filter.authorization.AuthorizationFilter:103)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:271)
-AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$531.1165582791.run()+12)
-AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction, java.security.AccessControlContext)+-1)
-AC Debugger:      at bundle-0(javax.security.auth.Subject:422)
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=1724)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.io.File:814) <instance of java.io.File(id=2088)>
+AC Debugger:  --> at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.NativeFontDirFinder:47) <instance of org.apache.fontbox.util.autodetect.MacFontDirFinder(id=2089)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.fontbox.util.autodetect.FontFileFinder:75) <instance of org.apache.fontbox.util.autodetect.FontFileFinder(id=2093)>
+AC Debugger:      at #*org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FileSystemFontProvider:214) <instance of org.apache.pdfbox.pdmodel.font.FileSystemFontProvider(id=2094)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl$DefaultFontProvider:130) <class of org.apache.pdfbox.pdmodel.font.FontMapperImpl$DefaultFontProvider>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:149) <instance of org.apache.pdfbox.pdmodel.font.FontMapperImpl(id=2095)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:413) <instance of org.apache.pdfbox.pdmodel.font.FontMapperImpl(id=2095)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:376) <instance of org.apache.pdfbox.pdmodel.font.FontMapperImpl(id=2095)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.FontMapperImpl:350) <instance of org.apache.pdfbox.pdmodel.font.FontMapperImpl(id=2095)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:146) <instance of org.apache.pdfbox.pdmodel.font.PDType1Font(id=2096)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.font.PDType1Font:79) <class of org.apache.pdfbox.pdmodel.font.PDType1Font>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:128) <instance of org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm(id=2097)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm:93) <instance of org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm(id=2097)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.pdmodel.PDDocumentCatalog:109) <instance of org.apache.pdfbox.pdmodel.PDDocumentCatalog(id=2098)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:598) <instance of org.apache.tika.parser.pdf.PDF2XHTML(id=2099)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.AbstractPDF2XHTML:545) <instance of org.apache.tika.parser.pdf.PDF2XHTML(id=2099)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.pdfbox.text.PDFTextStripper:267) <instance of org.apache.tika.parser.pdf.PDF2XHTML(id=2099)>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDF2XHTML:117) <class of org.apache.tika.parser.pdf.PDF2XHTML>
+AC Debugger:      at *org.codice.thirdparty.tika-bundle(org.apache.tika.parser.pdf.PDFParser:171) <instance of org.apache.tika.parser.pdf.PDFParser(id=2101)>
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280) <instance of org.apache.tika.parser.DefaultParser(id=2103)>
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280) <instance of org.apache.tika.parser.DefaultParser(id=2106)>
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.CompositeParser:280) <instance of org.apache.tika.parser.AutoDetectParser(id=2107)>
+AC Debugger:      at *org.apache.tika.core(org.apache.tika.parser.AutoDetectParser:143) <instance of org.apache.tika.parser.AutoDetectParser(id=2107)>
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:75) <instance of ddf.catalog.transformer.common.tika.TikaMetadataExtractor(id=2109)>
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.common.tika.TikaMetadataExtractor:68) <instance of ddf.catalog.transformer.common.tika.TikaMetadataExtractor(id=2109)>
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:229) <instance of ddf.catalog.transformer.input.pdf.PdfInputTransformer(id=2112)>
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:170) <instance of ddf.catalog.transformer.input.pdf.PdfInputTransformer(id=2112)>
+AC Debugger:      at *catalog-transformer-pdf(ddf.catalog.transformer.input.pdf.PdfInputTransformer:153) <instance of ddf.catalog.transformer.input.pdf.PdfInputTransformer(id=2112)>
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.MetacardFactory:75) <instance of ddf.catalog.impl.operations.MetacardFactory(id=2114)>
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.OperationsMetacardSupport:156) <instance of ddf.catalog.impl.operations.OperationsMetacardSupport(id=2117)>
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.operations.CreateOperations:141) <instance of ddf.catalog.impl.operations.CreateOperations(id=2119)>
+AC Debugger:      at *catalog-core-standardframework(ddf.catalog.impl.CatalogFrameworkImpl:237) <instance of ddf.catalog.impl.CatalogFrameworkImpl(id=2121)>
+AC Debugger:      at *catalog-rest-impl(Proxy905e4d32_0fbc_4807_b484_89b3e6deb928.create(ddf.catalog.content.operation.CreateStorageRequest)+58) <instance of Proxy905e4d32_0fbc_4807_b484_89b3e6deb928(id=2123)>
+AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:764) <instance of org.codice.ddf.rest.impl.CatalogServiceImpl(id=2127)>
+AC Debugger:      at *catalog-rest-impl(org.codice.ddf.rest.impl.CatalogServiceImpl:727) <instance of org.codice.ddf.rest.impl.CatalogServiceImpl(id=2127)>
+AC Debugger:      at *catalog-ui-search(Proxyf5cc0239_2d9c_43fe_ac67_d5c072bebf08.addDocument(java.util.List, javax.servlet.http.HttpServletRequest, java.lang.String, java.io.InputStream)+77) <instance of Proxyf5cc0239_2d9c_43fe_ac67_d5c072bebf08(id=2130)>
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:375) <instance of org.codice.ddf.catalog.ui.catalog.CatalogApplication(id=2133)>
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication:150) <instance of org.codice.ddf.catalog.ui.catalog.CatalogApplication(id=2133)>
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.catalog.CatalogApplication$$Lambda$1008.951120665.handle(spark.Request, spark.Response)+6) <instance of org.codice.ddf.catalog.ui.catalog.CatalogApplication$$Lambda$1008.951120665(id=2136)>
+AC Debugger:      at *catalog-ui-search(spark.RouteImpl$1:61) <instance of spark.RouteImpl$1(id=2138)>
+AC Debugger:      at *catalog-ui-search(spark.http.matching.Routes:61) <class of spark.http.matching.Routes>
+AC Debugger:      at *catalog-ui-search(spark.http.matching.MatcherFilter:130) <instance of spark.http.matching.MatcherFilter(id=2140)>
+AC Debugger:      at *catalog-ui-search(org.codice.ddf.catalog.ui.SparkServlet:146) <instance of org.codice.ddf.catalog.ui.SparkServlet(id=2142)>
+AC Debugger:      at *javax.servlet-api(javax.servlet.http.HttpServlet:790) <instance of org.codice.ddf.catalog.ui.SparkServlet(id=2142)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHolder:857) <instance of org.eclipse.jetty.servlet.ServletHolder(id=2146)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1655) <instance of org.eclipse.jetty.servlet.ServletHandler$CachedChain(id=2149)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:98) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *platform-filter-clientinfo(org.codice.ddf.platform.filter.clientinfo.ClientInfoFilter:72) <instance of org.codice.ddf.platform.filter.clientinfo.ClientInfoFilter(id=2154)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *platform-filter-response(org.codice.ddf.platform.response.filter.ResponseFilter:96) <instance of org.codice.ddf.platform.response.filter.ResponseFilter(id=2157)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *security-filter-authorization(org.codice.ddf.security.filter.authorization.AuthorizationFilter:103) <instance of org.codice.ddf.security.filter.authorization.AuthorizationFilter(id=2160)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:271) <class of org.codice.ddf.security.filter.login.LoginFilter>
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$642.1222613506.run()+12) <instance of org.codice.ddf.security.filter.login.LoginFilter$$Lambda$642.1222613506(id=2165)>
+AC Debugger:      at bundle-0(java.security.AccessController.doPrivileged(java.security.PrivilegedExceptionAction, java.security.AccessControlContext)+-1) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(javax.security.auth.Subject:422) <class of javax.security.auth.Subject>
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:281) <class of org.codice.ddf.security.filter.login.LoginFilter>
 AC Debugger:     ----------------------------------------------------------
-AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:281)
-AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$530.644881876.call()+16)
-AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:267)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:229)
-AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:122)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *security-filter-csrf(org.codice.ddf.security.filter.csrf.CsrfFilter:146)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91)
-AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.DelegateServletFilter:119)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
-AC Debugger:      at *org.eclipse.jetty.websocket.server(org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter:205)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1759)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:582)
-AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler:71)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:143)
-AC Debugger:      at *org.eclipse.jetty.security(org.eclipse.jetty.security.SecurityHandler:548)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:226)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1180)
-AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceContext:296)
-AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:512)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:185)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1112)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:141)
-AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection:80)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.HandlerWrapper:134)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.Server:539)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpChannel:333)
-AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpConnection:251)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.ssl.SslConnection:251)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:283)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:108)
-AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.SelectChannelEndPoint$2:93)
-AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:303)
-AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:148)
-AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume:136)
-AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool:671)
-AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool$2:589)
-AC Debugger:      at bundle-0(java.lang.Thread:748)
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter$$Lambda$641.490890921.call()+16) <instance of org.codice.ddf.security.filter.login.LoginFilter$$Lambda$641.490890921(id=2168)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=2170)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=2170)>
+AC Debugger:      at *org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=2174)>
+AC Debugger:      at *security-filter-login(org.codice.ddf.security.filter.login.LoginFilter:267) <instance of org.codice.ddf.security.filter.login.LoginFilter(id=2176)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:229) <instance of org.codice.ddf.security.filter.websso.WebSSOFilter(id=2178)>
+AC Debugger:      at *security-filter-web-sso(org.codice.ddf.security.filter.websso.WebSSOFilter:122) <instance of org.codice.ddf.security.filter.websso.WebSSOFilter(id=2178)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *security-filter-csrf(org.codice.ddf.security.filter.csrf.CsrfFilter:144) <instance of org.codice.ddf.security.filter.csrf.CsrfFilter(id=2182)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.ProxyFilterChain:91) <instance of org.codice.ddf.platform.filter.delegate.ProxyFilterChain(id=2151)>
+AC Debugger:      at *platform-filter-delegate(org.codice.ddf.platform.filter.delegate.DelegateServletFilter:119) <instance of org.codice.ddf.platform.filter.delegate.DelegateServletFilter(id=2186)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1642) <instance of org.eclipse.jetty.servlet.ServletHandler$CachedChain(id=2187)>
+AC Debugger:      at *org.eclipse.jetty.websocket.server(org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter:215) <instance of org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter(id=2189)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler$CachedChain:1642) <instance of org.eclipse.jetty.servlet.ServletHandler$CachedChain(id=2192)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:533) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler(id=2194)>
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler:71) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler(id=2194)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:146) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler(id=2194)>
+AC Debugger:      at *org.eclipse.jetty.security(org.eclipse.jetty.security.SecurityHandler:548) <instance of org.eclipse.jetty.security.ConstraintSecurityHandler(id=2202)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.HandlerWrapper:132) <instance of org.eclipse.jetty.server.session.SessionHandler(id=2207)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:257) <instance of org.eclipse.jetty.server.session.SessionHandler(id=2207)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:1595) <instance of org.eclipse.jetty.server.session.SessionHandler(id=2207)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:255) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1317) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.HttpServiceContext:293) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:203) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler(id=2194)>
+AC Debugger:      at *org.eclipse.jetty.servlet(org.eclipse.jetty.servlet.ServletHandler:473) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler(id=2194)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.session.SessionHandler:1564) <instance of org.eclipse.jetty.server.session.SessionHandler(id=2207)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:201) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ContextHandler:1219) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.ScopedHandler:144) <instance of org.ops4j.pax.web.service.jetty.internal.HttpServiceContext(id=2209)>
+AC Debugger:      at *org.ops4j.pax.web.pax-web-jetty(org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection:80) <instance of org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection(id=2213)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.handler.HandlerWrapper:132) <instance of org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper(id=2214)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.Server:531) <instance of org.ops4j.pax.web.service.jetty.internal.JettyServerWrapper(id=2214)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpChannel:352) <instance of org.eclipse.jetty.server.HttpChannelOverHttp(id=2218)>
+AC Debugger:      at *org.eclipse.jetty.server(org.eclipse.jetty.server.HttpConnection:260) <instance of org.eclipse.jetty.server.HttpConnection(id=2221)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.AbstractConnection$ReadCallback:281) <instance of org.eclipse.jetty.io.AbstractConnection$ReadCallback(id=2223)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:102) <instance of org.eclipse.jetty.io.AbstractEndPoint$1(id=2227)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.ssl.SslConnection:291) <instance of org.eclipse.jetty.io.ssl.SslConnection(id=2230)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.ssl.SslConnection$3:151) <instance of org.eclipse.jetty.io.ssl.SslConnection$3(id=2232)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.FillInterest:102) <instance of org.eclipse.jetty.io.AbstractEndPoint$1(id=2233)>
+AC Debugger:      at *org.eclipse.jetty.io(org.eclipse.jetty.io.ChannelEndPoint$2:118) <instance of org.eclipse.jetty.io.ChannelEndPoint$2(id=2235)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:333) <instance of org.eclipse.jetty.util.thread.strategy.EatWhatYouKill(id=2237)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:310) <instance of org.eclipse.jetty.util.thread.strategy.EatWhatYouKill(id=2237)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:168) <instance of org.eclipse.jetty.util.thread.strategy.EatWhatYouKill(id=2237)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.strategy.EatWhatYouKill:126) <instance of org.eclipse.jetty.util.thread.strategy.EatWhatYouKill(id=2237)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread:366) <instance of org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread(id=2241)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool:762) <instance of org.eclipse.jetty.util.thread.QueuedThreadPool(id=2243)>
+AC Debugger:      at *org.eclipse.jetty.util(org.eclipse.jetty.util.thread.QueuedThreadPool$2:680) <instance of org.eclipse.jetty.util.thread.QueuedThreadPool$2(id=2245)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='qtp2078420815-91', id=58)>
 ```
 
 The differences above lie in the permission which is reported as a matching regular expression from the pre-configured acceptable failure definition and in a `#` character seen in the 8th stack line which indicates the line was matched against the same pre-configured acceptable failure definition. 
 Since it is considered an acceptable failure, no solutions section will be printed out.
  
-Here is another example illustration a scenario where a combined access control context is in play within the security manager:
+Here is another example illustrating a scenario where a combined access control context is in play within the security manager:
 ```
-AC Debugger: 0001 - ACCESS CONTROL PERMISSION FAILURE
+AC Debugger: 0007 - ACCESS CONTROL PERMISSION FAILURE
 AC Debugger: ========================================
 AC Debugger: Permission:
-AC Debugger:     java.io.FilePermission "${/}ingest${/}metacard.xml", "read"
+AC Debugger:     java.io.FilePermission "${/}metacard.xml", "read"
 AC Debugger: Context:
 AC Debugger:      bundle-0
 AC Debugger:      catalog-core-commands
@@ -406,35 +429,158 @@ AC Debugger:      org.apache.karaf.shell.core
 AC Debugger:  --> *org.apache.karaf.shell.ssh (combined)
 AC Debugger:      *org.apache.sshd.core (combined)
 AC Debugger: Stack:
-AC Debugger:      at bundle-0(java.security.AccessControlContext:472)
-AC Debugger:      at bundle-0(java.security.AccessController:884)
-AC Debugger:      at bundle-0(java.lang.SecurityManager:549)
-AC Debugger:      at bundle-0(java.lang.SecurityManager:888)
-AC Debugger:      at bundle-0(java.io.File:814)
-AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:353)
-AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:249)
-AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$980.479024148.call()+4)
-AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90)
-AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83)
-AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:383)
-AC Debugger:      at catalog-core-commands(org.codice.ddf.security.common.Security:182)
-AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands:88)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229)
-AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59)
-AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266)
-AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142)
-AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617)
-AC Debugger:      at bundle-0(java.lang.Thread:748)
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=3225)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.io.File:814) <instance of java.io.File(id=3234)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:353) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:249) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$1405.1219594442.call()+4) <instance of org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$1405.1219594442(id=3235)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=3236)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=3236)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=3237)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.security.common.Security:182) <instance of org.codice.ddf.security.common.Security(id=2978)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands:88) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84) <instance of org.apache.karaf.shell.impl.action.command.ActionCommand(id=2984)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=2987)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=2987)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266) <instance of java.util.concurrent.FutureTask(id=2993)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142) <instance of java.util.concurrent.ThreadPoolExecutor(id=2995)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617) <instance of java.util.concurrent.ThreadPoolExecutor$Worker(id=2997)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='pipe-catalog:ingest /metacard.xml', id=2892)>
+AC Debugger: 
+AC Debugger: OPTION 1
+AC Debugger: --------
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${/}metacard.xml", "read"
+AC Debugger: Granting permission to bundles:
+AC Debugger:     org.apache.karaf.shell.ssh
+AC Debugger:     org.apache.sshd.core
+AC Debugger: Context:
+AC Debugger:      bundle-0
+AC Debugger:      catalog-core-commands
+AC Debugger:      org.apache.shiro.core
+AC Debugger:      org.apache.karaf.shell.core
+AC Debugger:      org.apache.karaf.shell.ssh (combined)
+AC Debugger:      org.apache.sshd.core (combined)
+AC Debugger: Stack:
+AC Debugger:      at bundle-0(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=3225)>
+AC Debugger:      at bundle-0(java.security.AccessController:884) <class of java.security.AccessController>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:549) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.lang.SecurityManager:888) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=2085)>
+AC Debugger:      at bundle-0(java.io.File:814) <instance of java.io.File(id=3234)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:353) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.IngestCommand:249) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$1405.1219594442.call()+4) <instance of org.codice.ddf.commands.catalog.SubjectCommands$$Lambda$1405.1219594442(id=3235)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:90) <instance of org.apache.shiro.subject.support.SubjectCallable(id=3236)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.SubjectCallable:83) <instance of org.apache.shiro.subject.support.SubjectCallable(id=3236)>
+AC Debugger:      at org.apache.shiro.core(org.apache.shiro.subject.support.DelegatingSubject:387) <instance of ddf.security.impl.SubjectImpl(id=3237)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.security.common.Security:182) <instance of org.codice.ddf.security.common.Security(id=2978)>
+AC Debugger:      at catalog-core-commands(org.codice.ddf.commands.catalog.SubjectCommands:88) <instance of org.codice.ddf.commands.catalog.IngestCommand(id=2981)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.action.command.ActionCommand:84) <instance of org.apache.karaf.shell.impl.action.command.ActionCommand(id=2984)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:68) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=2987)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand:86) <instance of org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand(id=2987)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:571) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:497) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Closure:386) <instance of org.apache.felix.gogo.runtime.Closure(id=2989)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:417) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:229) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at org.apache.karaf.shell.core(org.apache.felix.gogo.runtime.Pipe:59) <instance of org.apache.felix.gogo.runtime.Pipe(id=2991)>
+AC Debugger:      at bundle-0(java.util.concurrent.FutureTask:266) <instance of java.util.concurrent.FutureTask(id=2993)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor:1142) <instance of java.util.concurrent.ThreadPoolExecutor(id=2995)>
+AC Debugger:      at bundle-0(java.util.concurrent.ThreadPoolExecutor$Worker:617) <instance of java.util.concurrent.ThreadPoolExecutor$Worker(id=2997)>
+AC Debugger:      at bundle-0(java.lang.Thread:748) <instance of java.lang.Thread(name='pipe-catalog:ingest /metacard.xml', id=2892)>
+AC Debugger: 
+AC Debugger: SOLUTIONS
+AC Debugger: ---------
+AC Debugger: {
+AC Debugger:     Add the following permission block to the appropriate policy file:
+AC Debugger:         grant codeBase "file:/org.apache.karaf.shell.ssh/org.apache.sshd.core" {
+AC Debugger:             permission java.io.FilePermission "${/}metacard.xml", "read";
+AC Debugger:         }
+AC Debugger: }
 ```
 
 In such scenario, the access control context used by the security manager to verify permissions is composed of two parts: the first (as seen in other examples) comes from the current stack and the second part is inherited via a combined access control context. 
 Domains that are inherited are listed with **(combined)** next to them. 
 
 So in the above example, the security failure happens not because a class in the stack belongs to a bundle that doesn't have the right permission but because an inherited protection domain is associated with a bundle that doesn't have the permission.
+
+For Non-OSGi containers, the bundle name is simply replaced with the domain's codesource location. Instead of `bundle-0` we can see `boot:` to represent the boot classloader domain.
+
+Here is an example:
+```
+AC Debugger: 0039 - ACCESS CONTROL PERMISSION FAILURE
+AC Debugger: ========================================
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${solr.solr.home}${/}server${/}/lib${/}jts-core-1.15.0.jar", "read"
+AC Debugger: Context:
+AC Debugger:      boot:
+AC Debugger:  --> *file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar
+AC Debugger:      *file:${solr.solr.home}${/}server${/}start.jar
+AC Debugger: Stack:
+AC Debugger:      at boot:(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=799)>
+AC Debugger:      at boot:(java.security.AccessController:895) <class of java.security.AccessController>
+AC Debugger:  --> at *file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar(java.lang.SecurityManager:322) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=100)>
+AC Debugger:      at *file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar(java.lang.SecurityManager:661) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=100)>
+AC Debugger:      at boot:(sun.nio.fs.UnixPath:818) <instance of sun.nio.fs.UnixPath(id=803)>
+AC Debugger:      at boot:(sun.nio.fs.UnixFileAttributeViews$Basic:49) <instance of sun.nio.fs.UnixFileAttributeViews$Basic(id=804)>
+AC Debugger:      at boot:(sun.nio.fs.UnixFileSystemProvider:145) <instance of sun.nio.fs.MacOSXFileSystemProvider(id=123)>
+AC Debugger:      at boot:(java.nio.file.Files:1763) <class of java.nio.file.Files>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:219) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:276) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:373) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.Files:2760) <class of java.nio.file.Files>
+AC Debugger:      at *file:${solr.solr.home}${/}server/start.jar(org.eclipse.jetty.start.BaseHome:397) <instance of org.eclipse.jetty.start.BaseHome(id=111)>
+AC Debugger:      at *file:${solr.solr.home}${/}server/start.jar(org.eclipse.jetty.start.StartArgs:487) <instance of org.eclipse.jetty.start.StartArgs(id=602)>
+AC Debugger:      at *file:${solr.solr.home}${/}server/start.jar(org.eclipse.jetty.start.Main:351) <instance of org.eclipse.jetty.start.Main(id=112)>
+AC Debugger:      at boot:(org.eclipse.jetty.start.Main:75) <class of org.eclipse.jetty.start.Main>
+AC Debugger:
+AC Debugger: OPTION 1
+AC Debugger: --------
+AC Debugger: Permission:
+AC Debugger:     java.io.FilePermission "${solr.solr.home}${/}server${/}lib${/}jts-core-1.15.0.jar", "read"
+AC Debugger: Granting permission to domains:
+AC Debugger:     file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar
+AC Debugger:     file:${solr.solr.home}${/}server${/}start.jar
+AC Debugger: Context:
+AC Debugger:      boot:
+AC Debugger:      file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar
+AC Debugger:      file:${solr.solr.home}${/}server${/}start.jar
+AC Debugger: Stack:
+AC Debugger:      at boot:(java.security.AccessControlContext:472) <instance of java.security.AccessControlContext(id=799)>
+AC Debugger:      at boot:(java.security.AccessController:895) <class of java.security.AccessController>
+AC Debugger:      at file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar(java.lang.SecurityManager:322) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=100)>
+AC Debugger:      at file:${solr.solr.home}${/}security${/}pro-grade-1.1.3.jar(java.lang.SecurityManager:661) <instance of net.sourceforge.prograde.sm.ProGradeJSM(id=100)>
+AC Debugger:      at boot:(sun.nio.fs.UnixPath:818) <instance of sun.nio.fs.UnixPath(id=803)>
+AC Debugger:      at boot:(sun.nio.fs.UnixFileAttributeViews$Basic:49) <instance of sun.nio.fs.UnixFileAttributeViews$Basic(id=804)>
+AC Debugger:      at boot:(sun.nio.fs.UnixFileSystemProvider:145) <instance of sun.nio.fs.MacOSXFileSystemProvider(id=123)>
+AC Debugger:      at boot:(java.nio.file.Files:1763) <class of java.nio.file.Files>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:219) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:276) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.FileTreeWalker:373) <instance of java.nio.file.FileTreeWalker(id=610)>
+AC Debugger:      at boot:(java.nio.file.Files:2760) <class of java.nio.file.Files>
+AC Debugger:      at file:${solr.solr.home}${/}server${/}start.jar(org.eclipse.jetty.start.BaseHome:397) <instance of org.eclipse.jetty.start.BaseHome(id=111)>
+AC Debugger:      at file:${solr.solr.home}${/}server${/}start.jar(org.eclipse.jetty.start.StartArgs:487) <instance of org.eclipse.jetty.start.StartArgs(id=602)>
+AC Debugger:      at file:${solr.solr.home}${/}server${/}start.jar(org.eclipse.jetty.start.Main:351) <instance of org.eclipse.jetty.start.Main(id=112)>
+AC Debugger:      at boot:(org.eclipse.jetty.start.Main:75) <class of org.eclipse.jetty.start.Main>
+AC Debugger:
+AC Debugger: SOLUTIONS
+AC Debugger: ---------
+AC Debugger: {
+AC Debugger:     Add the following permission blocks to the appropriate policy file:
+AC Debugger:         grant codeBase "file:${solr.solr.home}${/}security/pro-grade-1.1.3.jar" {
+AC Debugger:             permission java.io.FilePermission "${solr.solr.home}${/}server${/}lib${/}jts-core-1.15.0.jar", "read";
+AC Debugger:         }
+AC Debugger:         grant codeBase "file:${solr.solr.home}${/}server/start.jar" {
+AC Debugger:             permission java.io.FilePermission "${solr.solr.home}${/}server${/}lib${/}jts-core-1.15.0.jar", "read";
+AC Debugger:         }
+AC Debugger: }
+```

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-
         <guava.version>23.0</guava.version>
         <gson.version>2.8.5</gson.version>
         <osgi.version>5.0.0</osgi.version>
@@ -66,7 +65,7 @@
         <!-- Maven Plugin Version Properties -->
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
         <dependency-check-maven.version>3.1.1</dependency-check-maven.version>
-        <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.8.2</maven-jacoco-plugin.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
### Description of the Change
This PR adds support for non-OSGi VM where it reports the domain codesource location where the failure is detected. It also sanitized its compatibility with Java 11 VMs.

It replace bundles with domains wherever it was more generic.
It adds class or instance location in debug output to better troubleshoot cases where the code is in a base class of a given object.
It adds system property expansion for domain locations and file permission names and made it configurable. It does so when both using or not using the backdoor.
It fixes when using backdoor to get bundle to rely on the result even if null.
It fixes printout.

### Benefits
The debugger can now be used when debugging non-OSGi VM and provides more debug information when needed.

### Verification Process
- Attempt to attach to DDF and verify debug output for known security exceptions.
- Attempt to attach to Solr and verify debug output

### Applicable Issues
Fixes: #36 