### PR TITLE
Disable docker unless on linux

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -47,7 +47,8 @@
             <id>docker</id>
             <activation>
                 <os>
-                    <family>!windows</family>
+                      <family>unix</family>
+                      <name>Linux</name>
                 </os>
             </activation>
             <build>


### PR DESCRIPTION
### Description of the Change
To make the docker build step work across multiple platforms some additional work needs to be done. For now it will only be enabled on linux
