### PR TITLE
Added acdebugger-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following modules are defined:
 * acdebugger-common
 * acdebugger-distribution
 * acdebugger-docker
+* acdebugger-maven-plugin
  
 #### acdebugger-api
 Defines a bundle that provides an interface for a permission service which is used by the backdoor bundle to temporarily grant missing permissions. This service should be registered by the VM.
@@ -148,6 +149,9 @@ Refer to [this page](docs/installing.md) for more information on installing the 
 #### acdebugger-docker
 Creates a docker image for acdebugger.
 Refer to [this page](docs/docker.md) for more information on using the docker container.
+
+#### acdebugger-maven-plugin
+Creates a maven plugin that can be used to start the AC Debugger in other maven projects.
 
 ### Future iterations
 Future implementations will:

--- a/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
+++ b/debugger/src/main/java/org/codice/acdebugger/ACDebugger.java
@@ -25,6 +25,8 @@ import org.codice.acdebugger.impl.Debugger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+// Important: The options are a copy of the ones in org.codice.acdebugger.plugin.ACDebuggerPlugin
+// and should be kept in sync
 @Command(
   description = "Purpose-built debugger for determining missing OSGi bundle security permissions.",
   name = "acdebugger",

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>acdebugger</artifactId>
+        <groupId>org.codice.acdebugger</groupId>
+        <version>1.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>acdebugger-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <name>AC Debugger :: Maven Plugin</name>
+
+    <properties>
+        <maven.version>3.3.9</maven.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.acdebugger</groupId>
+            <artifactId>acdebugger-debugger</artifactId>
+            <classifier>jar-with-dependencies</classifier>
+            <type>jar</type>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.71</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.76</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,46 +27,30 @@
 
     <name>AC Debugger :: Maven Plugin</name>
 
-    <properties>
-        <maven.version>3.3.9</maven.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5.1</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codice.acdebugger</groupId>
@@ -82,7 +66,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
             </plugin>
 
             <plugin>

--- a/plugin/src/main/java/org/codice/acdebugger/plugin/ACDebuggerPlugin.java
+++ b/plugin/src/main/java/org/codice/acdebugger/plugin/ACDebuggerPlugin.java
@@ -22,6 +22,15 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codice.acdebugger.Main;
 
+/**
+ * Maven plugin that starts the AC Debugger in a separate thread during a maven build. Default goal
+ * is on the 'pre-integration-test' phase but can be overridden in its configuration
+ *
+ * <p>can manually start the plugin by running: mvn acdebugger:start when added to a project
+ *
+ * <p>Important: The parameters are a direct copy of the ones in {@link
+ * org.codice.acdebugger.ACDebugger} and should be kept in sync
+ */
 @Mojo(name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
 public class ACDebuggerPlugin extends AbstractMojo {
   @Parameter private boolean skip;
@@ -36,7 +45,7 @@ public class ACDebuggerPlugin extends AbstractMojo {
 
   @Parameter private boolean wait;
 
-  @Parameter(defaultValue = "1")
+  @Parameter(defaultValue = "10")
   private int timeout;
 
   @Parameter private boolean reconnect;
@@ -76,7 +85,9 @@ public class ACDebuggerPlugin extends AbstractMojo {
     Runnable acdebugger = () -> Main.main(arguments.toArray(new String[0]));
     getLog()
         .info("Starting AC Debugger with the following options: " + String.join(" ", arguments));
-    new Thread(acdebugger).start();
+    Thread thread = new Thread(acdebugger, "AC Debugger Maven Plugin");
+    thread.setDaemon(true);
+    thread.start();
   }
 
   @VisibleForTesting

--- a/plugin/src/main/java/org/codice/acdebugger/plugin/ACDebuggerPlugin.java
+++ b/plugin/src/main/java/org/codice/acdebugger/plugin/ACDebuggerPlugin.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.plugin;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codice.acdebugger.Main;
+
+@Mojo(name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+public class ACDebuggerPlugin extends AbstractMojo {
+  @Parameter private boolean skip;
+
+  @Parameter private boolean remoteDebugging;
+
+  @Parameter(defaultValue = "localhost")
+  private String host;
+
+  @Parameter(defaultValue = "5005")
+  private String port;
+
+  @Parameter private boolean wait;
+
+  @Parameter(defaultValue = "1")
+  private int timeout;
+
+  @Parameter private boolean reconnect;
+
+  @Parameter private boolean continuous;
+
+  @Parameter private boolean admin;
+
+  @Parameter private boolean debug;
+
+  @Parameter private boolean service;
+
+  @Parameter private boolean fail;
+
+  @Parameter private boolean grant;
+
+  @Parameter(defaultValue = "true")
+  private boolean osgi;
+
+  @VisibleForTesting
+  ACDebuggerPlugin(Boolean skip, Boolean remoteDebugging) {
+    this.skip = skip;
+    this.remoteDebugging = remoteDebugging;
+  }
+
+  // Maven plugins need a default constructor if another constructor is defined
+  ACDebuggerPlugin() {}
+
+  @Override
+  public void execute() {
+    if (skip || remoteDebugging) {
+      getLog().info("skipping AC Debugger");
+      return;
+    }
+
+    List<String> arguments = buildArguments();
+    Runnable acdebugger = () -> Main.main(arguments.toArray(new String[0]));
+    getLog()
+        .info("Starting AC Debugger with the following options: " + String.join(" ", arguments));
+    new Thread(acdebugger).start();
+  }
+
+  @VisibleForTesting
+  List<String> buildArguments() {
+    List<String> arguments = new ArrayList<>();
+    addParameter(arguments, "--host", host);
+    addParameter(arguments, "--port", port);
+    addParameter(arguments, "--wait", wait);
+    addParameter(arguments, "--timeout", Integer.toString(timeout));
+    addParameter(arguments, "--reconnect", reconnect);
+    addParameter(arguments, "--continuous", continuous);
+    addParameter(arguments, "--admin", admin);
+    addParameter(arguments, "--debug", debug);
+    addParameter(arguments, "--service", service);
+    addParameter(arguments, "--fail", fail);
+    addParameter(arguments, "--grant", grant);
+    arguments.add("--osgi=" + osgi);
+
+    return arguments;
+  }
+
+  private void addParameter(List<String> list, String param, String value) {
+    list.add(param);
+    list.add(value);
+  }
+
+  private void addParameter(List<String> list, String param, boolean value) {
+    if (value) {
+      list.add(param);
+    }
+  }
+}

--- a/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
+++ b/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
@@ -56,7 +56,7 @@ class ACDebuggerPluginSpec extends Specification {
                         parameter('--reconnect', reconnect), parameter('--continuous', continuous), parameter('--admin', admin),
                         parameter('--debug', debug), parameter('--service', service), parameter('--fail', fail),
                         parameter('--grant', grant), (String)"--osgi=$osgi"]
-                .findAll({it != null})
+                .findAll{ it != null }
         then:
           arguments.containsAll(expected)
         where:

--- a/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
+++ b/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
@@ -34,7 +34,6 @@ class ACDebuggerPluginSpec extends Specification {
           plugin.execute()
         then:
           0 * plugin.buildArguments()
-          0 * plugin.buildCommand()
     }
 
     def "make sure we skip when remoteDebugging set to true"() {
@@ -44,7 +43,6 @@ class ACDebuggerPluginSpec extends Specification {
           plugin.execute()
         then:
           0 * plugin.buildArguments()
-          0 * plugin.buildCommand()
     }
 
     @Unroll
@@ -54,10 +52,10 @@ class ACDebuggerPluginSpec extends Specification {
                   admin: admin, debug: debug, service: service, fail: fail, grant: grant, osgi: osgi)
         when:
         def arguments = plugin.buildArguments()
-        def expected = ["--host", host, "--port", port, parameter("--wait", wait), "--timeout", timeout,
-                        parameter("--reconnect", reconnect), parameter("--continuous", continuous), parameter("--admin", admin),
-                        parameter("--debug", debug), parameter("--service", service), parameter("--fail", fail),
-                        parameter("--grant", grant), (String)"--osgi=$osgi"]
+        def expected = ['--host', host, '--port', port, parameter('--wait', wait), '--timeout', timeout,
+                        parameter('--reconnect', reconnect), parameter('--continuous', continuous), parameter('--admin', admin),
+                        parameter('--debug', debug), parameter('--service', service), parameter('--fail', fail),
+                        parameter('--grant', grant), (String)"--osgi=$osgi"]
                 .findAll({it != null})
         then:
           arguments.containsAll(expected)

--- a/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
+++ b/plugin/src/test/groovy/org/codice/acdebugger/plugin/ACDebuggerPluginSpec.groovy
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.acdebugger.plugin
+
+import org.apache.maven.plugin.testing.MojoRule
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ACDebuggerPluginSpec extends Specification {
+    @Rule
+    MojoRule rule = new MojoRule()
+
+    def "make sure we can load the plugin"() {
+        expect:
+          loadPlugin() != null
+    }
+
+    def "make sure we skip when skip set to true"() {
+        given:
+          ACDebuggerPlugin plugin = Spy(constructorArgs: [true, false])
+        when:
+          plugin.execute()
+        then:
+          0 * plugin.buildArguments()
+          0 * plugin.buildCommand()
+    }
+
+    def "make sure we skip when remoteDebugging set to true"() {
+        given:
+          ACDebuggerPlugin plugin = Spy(constructorArgs: [false, true])
+        when:
+          plugin.execute()
+        then:
+          0 * plugin.buildArguments()
+          0 * plugin.buildCommand()
+    }
+
+    @Unroll
+    def "test buildArguments() when #when_what"() {
+        given:
+          def plugin = loadPlugin(host: host, port: port, wait: wait, timeout: timeout, reconnect: reconnect, continuous: continuous,
+                  admin: admin, debug: debug, service: service, fail: fail, grant: grant, osgi: osgi)
+        when:
+        def arguments = plugin.buildArguments()
+        def expected = ["--host", host, "--port", port, parameter("--wait", wait), "--timeout", timeout,
+                        parameter("--reconnect", reconnect), parameter("--continuous", continuous), parameter("--admin", admin),
+                        parameter("--debug", debug), parameter("--service", service), parameter("--fail", fail),
+                        parameter("--grant", grant), (String)"--osgi=$osgi"]
+                .findAll({it != null})
+        then:
+          arguments.containsAll(expected)
+        where:
+          when_what                     || host        | port   | wait  | timeout | reconnect | continuous | admin | debug | service | fail  | grant | osgi
+          "all options are enabled"     || "localhost" | "1234" | true  | "100"   | true      | true       | true  | true  | true    | true  | true  | true
+          "all options are disabled"    || "localhost" | "1234" | false | "0"     | false     | false      | false | false | false   | false | false | false
+    }
+
+    ACDebuggerPlugin loadPlugin(Map args = [:]) {
+        def baseDir = new File("target/test-classes/project-to-test/")
+        def project = rule.readMavenProject(baseDir)
+        def properties = project.properties
+        properties.setProperty("host", args.host ?: "localhost")
+        properties.setProperty("port", args.port ?: "1234")
+        properties.setProperty("wait", Boolean.toString((boolean)args.wait))
+        properties.setProperty("timeout", args.timeout ?: "5")
+        properties.setProperty("reconnect", Boolean.toString((boolean)args.reconnect))
+        properties.setProperty("continuous", Boolean.toString((boolean)args.continuous))
+        properties.setProperty("admin", Boolean.toString((boolean)args.admin))
+        properties.setProperty("debug", Boolean.toString((boolean)args.debug))
+        properties.setProperty("service", Boolean.toString((boolean)args.service))
+        properties.setProperty("fail", Boolean.toString((boolean)args.fail))
+        properties.setProperty("grant", Boolean.toString((boolean)args.grant))
+        properties.setProperty("osgi", Boolean.toString(args.osgi == null ? true : args.osgi))
+        properties.setProperty("skip", Boolean.toString((boolean)args.skip))
+        properties.setProperty("remoteDebugging", Boolean.toString((boolean)args.remoteDebugging))
+
+
+        return rule.lookupConfiguredMojo(project, "start") as ACDebuggerPlugin
+    }
+
+    String parameter(String name, boolean value) {
+        return value ? name : null
+    }
+}

--- a/plugin/src/test/resources/project-to-test/pom.xml
+++ b/plugin/src/test/resources/project-to-test/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codice.acdebugger</groupId>
+    <artifactId>acdebugger-maven-plugin-test</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+    <name>Test AC Debugger Maven Plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codice.acdebugger</groupId>
+                <artifactId>acdebugger-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${skip}</skip>
+                    <remoteDebugging>${remoteDebugging}</remoteDebugging>
+                    <host>${host}</host>
+                    <port>${port}</port>
+                    <wait>${wait}</wait>
+                    <timeout>${timeout}</timeout>
+                    <reconnect>${reconnect}</reconnect>
+                    <continuous>${continuous}</continuous>
+                    <admin>${admin}</admin>
+                    <debug>${debug}</debug>
+                    <service>${service}</service>
+                    <fail>${fail}</fail>
+                    <grant>${grant}</grant>
+                    <osgi>${osgi}</osgi>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,14 @@
         <eclipse-osgi.version>3.11.3</eclipse-osgi.version>
         <jsr305.version>3.0.2_1</jsr305.version>
         <picocli.version>3.5.2</picocli.version>
+        <maven.version>3.3.9</maven.version>
+        <maven-plugin-annotations.version>3.5.1</maven-plugin-annotations.version>
 
         <junit.version>4.12</junit.version>
         <groovy.version>2.4.7</groovy.version>
         <mockito-core.version>2.8.47</mockito-core.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
+        <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
 
         <!-- Gitflow Incremental Builder Properties -->
         <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
@@ -72,6 +75,7 @@
         <dependency-check-maven.version>3.1.1</dependency-check-maven.version>
         <maven-jacoco-plugin.version>0.8.2</maven-jacoco-plugin.version>
         <fabric8.docker.plugin.version>0.27.1</fabric8.docker.plugin.version>
+        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     </properties>
 
     <scm>
@@ -155,6 +159,42 @@
                 <groupId>org.codice.pro-grade</groupId>
                 <artifactId>pro-grade</artifactId>
                 <version>1.1.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven-plugin-annotations.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${maven.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-testing</groupId>
+                <artifactId>maven-plugin-testing-harness</artifactId>
+                <version>${maven-plugin-testing-harness.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -273,6 +313,11 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${fabric8.docker.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>${maven-plugin-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,23 @@
         <tag>acdebugger-1.6</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>codice</id>
+            <name>Codice Repository</name>
+            <url>https://artifacts.codice.org/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <!--
           NOTE: The properties snapshots.repository.url and releases.repository.url should be defined in your .m2/settings.xml file.
@@ -444,5 +461,6 @@
         <module>backdoor</module>
         <module>distribution</module>
         <module>docker</module>
+        <module>plugin</module>
     </modules>
 </project>


### PR DESCRIPTION
### Requirements
* Start the ACDebugger from a maven build
* Pass in configurations from a pom.xml
* Starts in a separate thread or process.

### Description of the Change
<!--
We must be able to understand the design of your change from this
description. If we can't get a good idea of what the code will be doing
from the description here, the pull request may be closed at the
maintainers' discretion. Keep in mind that the maintainer reviewing this
PR may not be familiar with or have worked with the code here recently,
so please walk us through the concepts.
-->
Created a maven plugin that will launch the ACDebugger during the pre-integration-test phase.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed
version was selected
-->
Initially had the plugin start the ACDebugger in a separate JVM process, but then went with a new thread. When maven finishes the build it will automatically kill the thread when maven's JVM is stopped.

### Benefits
<!--
What benefits will be realized by the code change?
-->
Allows easy integration with other maven projects.

### Possible Drawbacks
<!--
What are the possible side-effects or negative impacts of the code change?
-->

### Verification Process
<!--
What process did you follow to verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->
Added unit/integration test for the maven plugin using maven-test-harness
Verified it works in a separate maven project

### Applicable Issues
<!--
Enter applicable Issues here
-->
Fixes: #46 