### PR TITLE
ACD - Added jline acceptable security exception

### DIFF
--- a/debugger/src/main/resources/acceptable-security-check-failures.txt
+++ b/debugger/src/main/resources/acceptable-security-check-failures.txt
@@ -17,7 +17,7 @@ org\.apache\.pdfbox\.pdmodel\.font\.FileSystemFontProvider.*
 java\.io\.FilePermission ".*somaxconn", "read"
 io\.netty\.util\.NetUtil\$.*:267
 
-# At startup time, Karaf tries to create a system terminal and will fall back to a dumb one of it c
+# At startup time, Karaf tries to create a system terminal and will fall back to a dumb one of it
 # cannot.
 java\.io\.FilePermission "<<ALL FILES>>", "execute"
 org\.jline\.utils\.ExecHelper:35

--- a/debugger/src/main/resources/acceptable-security-check-failures.txt
+++ b/debugger/src/main/resources/acceptable-security-check-failures.txt
@@ -17,7 +17,7 @@ org\.apache\.pdfbox\.pdmodel\.font\.FileSystemFontProvider.*
 java\.io\.FilePermission ".*somaxconn", "read"
 io\.netty\.util\.NetUtil\$.*:267
 
-# At startup time, Karaf tries to create a system terminal and will fall back to a dumb one of it
+# At startup time, Karaf tries to create a system terminal and will fall back to a dumb one if it
 # cannot.
 java\.io\.FilePermission "<<ALL FILES>>", "execute"
 org\.jline\.utils\.ExecHelper:35

--- a/debugger/src/main/resources/acceptable-security-check-failures.txt
+++ b/debugger/src/main/resources/acceptable-security-check-failures.txt
@@ -16,3 +16,9 @@ org\.apache\.pdfbox\.pdmodel\.font\.FileSystemFontProvider.*
 # continue with a valid default for Windows
 java\.io\.FilePermission ".*somaxconn", "read"
 io\.netty\.util\.NetUtil\$.*:267
+
+# At startup time, Karaf tries to create a system terminal and will fall back to a dumb one of it c
+# cannot.
+java\.io\.FilePermission "<<ALL FILES>>", "execute"
+org\.jline\.utils\.ExecHelper:35
+org\.jline\.terminal\.TerminalBuilder:376


### PR DESCRIPTION
### Description of the Change
Added jline acceptable security exception to handle failure creating a system terminal which falls back to a dumb one.

### Alternate Designs
None

### Benefits
All DDF itests are reporting this failure which is an acceptable one. This will make the debugger report it as an acceptable one from now on.

### Possible Drawbacks
None

### Verification Process
Run DDF itests with this new debugger and see it reported as acceptable.

### Applicable Issues
Fixes: #___