### PR TITLE
Commented out the windows stages and upgraded dependency-check to 5.2.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,15 +95,15 @@ pipeline {
                         }
                     }
                 }
-                stage ('Windows') {
-                    agent { label 'server-2016-small' }
-                    steps {
-                        withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
-                              bat 'mvn install -B -DskipStatic=true -DskipTests=true %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
-                              bat 'mvn clean install -B -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET% %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
-                        }
-                    }
-                }
+                // stage ('Windows') {
+                //     agent { label 'server-2016-small' }
+                //     steps {
+                //         withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
+                //               bat 'mvn install -B -DskipStatic=true -DskipTests=true %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                //               bat 'mvn clean install -B -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET% %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                //         }
+                //     }
+                // }
             }
         }
         stage('Full Build') {
@@ -137,14 +137,14 @@ pipeline {
                         }
                     }
                 }
-                stage ('Windows') {
-                    agent { label 'server-2016-small'}
-                    steps {
-                        withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
-                              bat 'mvn clean install -B %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
-                        }
-                    }
-                }
+                // stage ('Windows') {
+                //     agent { label 'server-2016-small'}
+                //     steps {
+                //         withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
+                //               bat 'mvn clean install -B %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                //         }
+                //     }
+                // }
             }
         }
         /*

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,8 @@
                                 ${highest-basedir}/dependency-check-maven-config.xml
                             </suppressionFile>
                         </suppressionFiles>
+                        <!-- This prevents a build failure on jdk tools jar -->
+                        <skipSystemScope>true</skipSystemScope>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <!-- Maven Plugin Version Properties -->
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
-        <dependency-check-maven.version>3.1.1</dependency-check-maven.version>
+        <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
         <maven-jacoco-plugin.version>0.8.2</maven-jacoco-plugin.version>
         <fabric8.docker.plugin.version>0.27.1</fabric8.docker.plugin.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
@@ -256,10 +256,8 @@
                     <version>${dependency-check-maven.version}</version>
                     <configuration>
                         <!-- The following properties enable using a mirror for nist NVD data -->
-                        <cveUrl12Modified>${owasp.cveUrl12Modified}</cveUrl12Modified>
-                        <cveUrl20Modified>${owasp.cveUrl20Modified}</cveUrl20Modified>
-                        <cveUrl12Base>${owasp.cveUrl12Base}</cveUrl12Base>
-                        <cveUrl20Base>${owasp.cveUrl20Base}</cveUrl20Base>
+                        <cveUrlModified>${owasp.cveUrlModified}</cveUrlModified>
+                        <cveUrlBase>${owasp.cveUrlBase}</cveUrlBase>
                         <!-- End NVD mirror configuration -->
                         <failBuildOnCVSS>2</failBuildOnCVSS>
                         <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
Windows nodes are no longer available on the build system.

### Description of the Change

Commented out the windows stages in the Jenkinsfile.
Windows nodes are no longer available on the build system.

@shaundmorris 
@TonyMorrison 
@LinkMJB 
@oconnormi 
Can I get a review?